### PR TITLE
Fix flaky test on distributions::extreme.py, distributions::gama.py, and distributions::student.py

### DIFF
--- a/tests/distributions/extreme.py
+++ b/tests/distributions/extreme.py
@@ -15,8 +15,8 @@ class GeneralizedExtremeValueUncertaintyTestCase(UncertaintyTestCase):
         results = GEVU.random_variables(params, 10000)
         found_median = np.median(results)
         self.assertEqual(results.shape, (1, 10000))
-        self.assertTrue(0.95 * expected_median < found_median)
-        self.assertTrue(found_median < 1.05 * expected_median)
+        self.assertTrue(0.9 * expected_median < found_median)
+        self.assertTrue(found_median < 1.1 * expected_median)
 
     def test_loc_validation(self):
         params = self.make_params_array()

--- a/tests/distributions/gamma.py
+++ b/tests/distributions/gamma.py
@@ -10,7 +10,7 @@ class GammaUncertaintyTestCase(UncertaintyTestCase):
         if b == 0:
             self.assertTrue(a - 0.05 < b < a + 0.05)
         else:
-            self.assertTrue(0.95 * a < b < 1.05 * a)
+            self.assertTrue(0.9 * a < b < 1.1 * a)
 
     def test_random_variables(self):
         params = self.make_params_array()

--- a/tests/distributions/student.py
+++ b/tests/distributions/student.py
@@ -10,7 +10,7 @@ class StudentsTTestCase(UncertaintyTestCase):
         if b == 0:
             self.assertTrue(a - 0.1 < b < a + 0.1)
         else:
-            self.assertTrue(0.95 * a < b < 1.05 * a)
+            self.assertTrue(0.9 * a < b < 1.1 * a)
 
     def test_loc_and_scale_nan(self):
         params = self.make_params_array()
@@ -29,7 +29,7 @@ class StudentsTTestCase(UncertaintyTestCase):
         params = self.make_params_array()
         params['shape'] = 1
         sample_1 = StudentsTUncertainty.random_variables(params, 5000)
-        params['scale'] = 5
+        params['scale'] = 1000
         sample_2 = StudentsTUncertainty.random_variables(params, 5000)
         self.assertTrue(np.std(sample_1) < np.std(sample_2))
 


### PR DESCRIPTION
This PR aims to fix the flaky test on `distributions::extreme.py::GeneralizedExtremeValueUncertaintyTestCase::test_random_variables`
`distributions::gama.py::GammaUncertaintyTestCase::::pretty_close` 
`distributions::student.py::GammaUncertaintyTestCase::::test_scale_matters`  so the test could pass single run, multiple test run, and random test run.

#### The result

These three tests will fail on the multipe re-runs with pytest flake-finder, the following error will raised randomly on the re-runs and possibly raised during user's usage

for extreme.py
`distributions/extreme.py:18: in test_random_variables`
 `       self.assertTrue(0.95 * expected_median < found_median)
E   AssertionError: False is not true`
or
`        self.assertTrue(found_median < 1.05 * expected_median)
E   AssertionError: False is not true
`
for gama.py
`self.pretty_close(np.var(sample), expected_variance)`
`distributions/gamma.py:13: in pretty_close
    self.assertTrue(0.95 * a < b < 1.05 * a)
E   AssertionError: False is not true
`
for student.py
`>       self.assertTrue(np.std(sample_1) < np.std(sample_2))`
`E       AssertionError: False is not true`

#### Steps to reproduce the issue

1.  install pytest flaky finder with `pip install pytest-flakefinder`
2.  run pytest with flake-finder with command  `pytest -k tests/distributions/extreme.py --flake-finder --flake-runs=50`  
`pytest -k tests/distributions/gamma.py --flake-finder --flake-runs=500`
`pytest -k tests/distributions/student.py --flake-finder --flake-runs=500`


#### Issue of the code

For extreme.py and gamma.py, the reason is that the failure test use np.random to generate list and calculating depends on the result list, which might sometimes reach beyond the 95%-105% percentage range and it causes about 6%(3 out of 50) test fails, therefore I increase the assertion range to 90%-110%, which will not fail in 500 re-runs.

For the student.py, besides the assertion range issue, the `test_scale_matters` use scale to initialize list and compare the std, the original parameters are 1 and 5, which will give about 15 fail runs out of 500. I increase the parameter to 1 and 1000, which will not fail on 500 re-runs.

#### Proposed solution
Increase the assertion range to 0.9 < test result <1.1 and increase the parameter to create list from 5 to 1000 and the test suit will not fail on at least 500 runs.

