### PR TITLE
Move argsort to save on execution time.

### DIFF
--- a/stats_arrays/random.py
+++ b/stats_arrays/random.py
@@ -145,6 +145,7 @@ Returns:
         self.random = np.random.RandomState(seed)
         self.verify_params()
         self.ordering = np.argsort(self.params["uncertainty_type"])
+        self.reverse_ordering = np.argsort(self.ordering)
         self.params = self.params[self.ordering]
         self.positions = self.get_positions()
 
@@ -195,7 +196,7 @@ Returns:
                 self.random_data[offset:numparams + offset, :] = random_data
             offset += numparams
 
-        self.random_data = self.random_data[np.argsort(self.ordering)]
+        self.random_data = self.random_data[self.reverse_ordering]
         return self.random_data
 
     def next(self):


### PR DESCRIPTION
When profiling MonteCarlo runs, I ran into a suspicious node in the call graph:
![call_graph_argsort_cropped](https://github.com/brightway-lca/stats_arrays/assets/6737625/8621c2e2-8c64-417b-815e-38d4bb0c2567)

It turns out the reverse ordering of the parameter array for the distribution function is generated every time `generate` is called, which is rather expensive. Since the ordering does not change after initialization as far as I can tell, it might make sense to move the reverse ordering to the `__init__`. If the ordering is modified, however, it might make sense to keep things as they are (or expose a modification function that also takes care of the reverse ordering).