### PR TITLE
Fix lognormal PDF range: use exp(μ) instead of μ for x-axis bounds

### DIFF
--- a/src/stats_arrays/distributions/lognormal.py
+++ b/src/stats_arrays/distributions/lognormal.py
@@ -114,12 +114,12 @@ class LognormalUncertainty(UncertaintyBase):
             # Find nice range to graph
             lower = (
                 (-1 if n else 1)
-                * params["loc"]
+                * np.exp(params["loc"])
                 / (np.exp(params["scale"]) ** cls.standard_deviations_in_default_range)
             )[0, 0]
             upper = (
                 (-1 if n else 1)
-                * params["loc"]
+                * np.exp(params["loc"])
                 * (np.exp(params["scale"]) ** cls.standard_deviations_in_default_range)
             )[0, 0]
             if n:


### PR DESCRIPTION
## Summary

- `LognormalUncertainty.pdf()` was computing its default x-axis range using `params["loc"]` (μ, the log-space mean) instead of `np.exp(params["loc"])` (the geometric mean, in real space)
- For μ=0 (the common case where the geometric mean is 1), this produced `lower = upper = 0`, making the PDF completely degenerate
- The fix replaces both occurrences with `np.exp(params["loc"])`, consistent with how `statistics()` already computes the same bounds via `geometric_mu`

Fixes #20

## Test plan

- [ ] `tests/distributions/test_lognormal.py` — all 13 existing tests pass
- [ ] Manual check: `pdf()` with μ=0 now returns a sensible x range centred on 1.0 (e.g. [0.33, 3.0] for σ=0.5)