### PR TITLE
Fix Bernoulli CDF and PPF: both were logically inverted

### DIFF
--- a/src/stats_arrays/distributions/bernoulli.py
+++ b/src/stats_arrays/distributions/bernoulli.py
@@ -42,9 +42,10 @@ class BernoulliUncertainty(UncertaintyBase):
     @classmethod
     def cdf(cls, params: ParamsArray, vector: npt.NDArray) -> npt.NDArray:
         vector = cls.check_2d_inputs(params, vector)
-        return (vector <= params["loc"].reshape(-1, 1)) * 1.0
+        p = params["loc"].reshape(-1, 1)
+        return np.where(vector < 0, 0.0, np.where(vector < 1, 1 - p, 1.0))
 
     @classmethod
     def ppf(cls, params: ParamsArray, percentages: npt.NDArray) -> npt.NDArray:
         percentages = cls.check_2d_inputs(params, percentages)
-        return (percentages <= params["loc"].reshape(-1, 1)) * 1.0
+        return (percentages > 1 - params["loc"].reshape(-1, 1)) * 1.0

--- a/tests/distributions/test_bernoulli.py
+++ b/tests/distributions/test_bernoulli.py
@@ -50,39 +50,39 @@ def bernoulli_params_2d():
 
 
 def test_bernoulli_ppf(bernoulli_params_1d, bernoulli_params_2d):
-    """PPF returns 1/0 based on if percentage <= loc threshold."""
-    # For loc=0.3, percentages <= 0.3 should be 1, percentages > 0.3 should be 0
+    """PPF returns 1 when q > 1-p, else 0."""
+    # For loc=0.3: threshold is 1-0.3=0.7; q > 0.7 → 1, q <= 0.7 → 0
     result = BernoulliUncertainty.ppf(
         bernoulli_params_1d, np.array([[0, 0.25, 0.5, 0.75, 1]])
     )
-    expected = np.array(
-        [[1.0, 1.0, 0.0, 0.0, 0.0]]
-    )  # 0, 0.25 <= 0.3 → 1; 0.5, 0.75, 1 > 0.3 → 0
+    expected = np.array([[0.0, 0.0, 0.0, 1.0, 1.0]])
     assert np.allclose(result, expected)
 
-    # For loc=[0.3, 0.7] - percentages per row compared to respective loc
+    # For loc=[0.3, 0.7]: thresholds are 0.7 and 0.3 respectively
     result = BernoulliUncertainty.ppf(
         bernoulli_params_2d, np.array([[0.2, 0.5], [0.2, 0.5]])
     )
-    # First row: 0.2 <= 0.3 → 1, 0.5 > 0.3 → 0
-    # Second row: 0.2 <= 0.7 → 1, 0.5 <= 0.7 → 1
-    expected = np.array([[1.0, 0.0], [1.0, 1.0]])
+    # Row 0 (p=0.3, threshold=0.7): 0.2 <= 0.7 → 0, 0.5 <= 0.7 → 0
+    # Row 1 (p=0.7, threshold=0.3): 0.2 <= 0.3 → 0, 0.5 > 0.3 → 1
+    expected = np.array([[0.0, 0.0], [0.0, 1.0]])
     assert np.allclose(result, expected)
 
 
 def test_bernoulli_cdf(bernoulli_params_1d, bernoulli_params_2d):
-    """CDF returns 1 if vector <= loc, else 0."""
-    # For loc=0.3, values <= 0.3 should return 1
+    """CDF is 0 for x<0, (1-p) for 0<=x<1, 1 for x>=1."""
+    # For loc=0.3: CDF is 0 below 0, 0.7 in [0,1), 1 at and above 1
     assert np.allclose(
         BernoulliUncertainty.cdf(
-            bernoulli_params_1d, np.array([[0, 0.2, 0.3, 0.5, 1]])
+            bernoulli_params_1d, np.array([[-1, 0, 0.5, 1]])
         ),
-        np.array([[1, 1, 1, 0, 0]]),  # 0, 0.2, 0.3 <= 0.3 → 1; 0.5, 1 > 0.3 → 0
+        np.array([[0.0, 0.7, 0.7, 1.0]]),
     )
-    # For loc=[0.3, 0.7]
+    # For loc=[0.3, 0.7]: each row evaluated at x=0.5 (which is in [0,1))
+    # Row 0 (p=0.3): CDF(0.2) = 1-0.3 = 0.7
+    # Row 1 (p=0.7): CDF(0.5) = 1-0.7 = 0.3
     assert np.allclose(
         BernoulliUncertainty.cdf(bernoulli_params_2d, np.array([0.2, 0.5])),
-        np.array([[1], [1]]),  # 0.2 <= 0.3 → 1; 0.5 <= 0.7 → 1
+        np.array([[0.7], [0.3]]),
     )
 
 

--- a/tests/test_lhc.py
+++ b/tests/test_lhc.py
@@ -473,19 +473,8 @@ def test_bernoulli():
         lhc.hypercube,
         np.array(
             [
-                [
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                    0,
-                    0,
-                    0,
-                    0,
-                ],
-                [1, 1, 1, 1, 1, 1, 0, 0, 0, 0],
+                [0, 0, 0, 0, 1, 1, 1, 1, 1, 1],
+                [0, 0, 0, 0, 1, 1, 1, 1, 1, 1],
             ]
         ),
     )
@@ -495,7 +484,7 @@ def test_bernoulli():
     params["uncertainty_type"] = BernoulliUncertainty.id
     params["loc"] = 0.4
     lhc = LatinHypercubeRNG(params)
-    assert np.allclose(lhc.hypercube, np.array([1, 1, 1, 1, 0, 0, 0, 0, 0, 0]))
+    assert np.allclose(lhc.hypercube, np.array([0, 0, 0, 0, 0, 0, 1, 1, 1, 1]))
 
 
 def test_heterogeneous_params():


### PR DESCRIPTION
## Summary

- `BernoulliUncertainty.cdf` was returning `(x <= p)`, which is wrong. The correct Bernoulli CDF is `0` for `x<0`, `1-p` for `0≤x<1`, `1` for `x≥1`.
- `BernoulliUncertainty.ppf` was returning `(q <= p)` instead of `(q > 1-p)`, producing the complement of the correct quantiles.
- Both methods were producing nonsense results for LHC sampling.
- Two tests that had been written to match the old wrong behaviour are updated to reflect the correct Bernoulli CDF/PPF.

Fixes #21

## Test plan

- [ ] `tests/distributions/test_bernoulli.py` — all 7 tests pass
- [ ] Manual check: `cdf(p=0.3, x=[−1, 0, 0.5, 1])` → `[0, 0.7, 0.7, 1.0]`
- [ ] Manual check: `ppf(p=0.3, q=[0, 0.5, 0.7, 0.71, 1])` → `[0, 0, 0, 1, 1]`