### PR TITLE
Fix DiscreteUniform CDF: pass low/high as positional args to scipy.stats.randint

### DIFF
--- a/src/stats_arrays/distributions/discrete_uniform.py
+++ b/src/stats_arrays/distributions/discrete_uniform.py
@@ -65,8 +65,8 @@ class DiscreteUniform(UncertaintyBase):
         for row in range(params.shape[0]):
             results[row, :] = stats.randint.cdf(
                 vector[row, :],
-                loc=params[row]["minimum"],
-                scale=params[row]["maximum"] - params[row]["minimum"],
+                params[row]["minimum"],  # low (shape param)
+                params[row]["maximum"],  # high (shape param)
             )
         return results
 


### PR DESCRIPTION
## Summary

- `DiscreteUniform.cdf` was calling `stats.randint.cdf(k, loc=minimum, scale=maximum−minimum)`, which does **not** set the `low` and `high` shape parameters for `scipy.stats.randint`
- With shape params left at their defaults (low=0, high=1), the CDF was completely wrong and inconsistent with `random_variables()`, which correctly used `numpy.random.randint(minimum, maximum)`
- Fix: pass `minimum` and `maximum` as positional shape arguments — `stats.randint.cdf(k, minimum, maximum)`

Fixes #22

## Test plan

- [ ] `tests/distributions/test_discrete_uniform.py` — all 3 existing tests pass
- [ ] Manual check: for range [2, 8), `cdf([1,2,3,4,5,6,7,8])` → `[0, 1/6, 2/6, 3/6, 4/6, 5/6, 1, 1]`