### PR TITLE
Add NaN checks to Weibull and GEV validate()

### DIFF
--- a/src/stats_arrays/distributions/extreme.py
+++ b/src/stats_arrays/distributions/extreme.py
@@ -25,7 +25,7 @@ class GeneralizedExtremeValueUncertainty(UncertaintyBase):
             raise InvalidParamsError(
                 "Real ``mu`` values needed for generalized extreme value."
             )
-        if (params["scale"] <= 0).sum():
+        if (params["scale"] <= 0).sum() or np.isnan(params["scale"]).sum():
             raise InvalidParamsError(
                 "Real, positive ``sigma`` values need for generalized extreme value."
             )

--- a/src/stats_arrays/distributions/weibull.py
+++ b/src/stats_arrays/distributions/weibull.py
@@ -24,9 +24,9 @@ class WeibullUncertainty(UncertaintyBase):
 
     @classmethod
     def validate(cls, params: ParamsArray) -> None:
-        if (params["shape"] <= 0).sum():
+        if (params["shape"] <= 0).sum() or np.isnan(params["shape"]).sum():
             raise InvalidParamsError("Real, positive ``k`` values need for Weibull.")
-        if (params["scale"] <= 0).sum():
+        if (params["scale"] <= 0).sum() or np.isnan(params["scale"]).sum():
             raise InvalidParamsError(
                 "Real, positive ``lambda`` values need for Weibull."
             )


### PR DESCRIPTION
## Summary

- `WeibullUncertainty.validate` and `GeneralizedExtremeValueUncertainty.validate` only checked `(param <= 0)` for shape and scale, but `NaN <= 0` is `False` in numpy, so NaN values silently passed and produced NaN samples
- Added `or np.isnan(param).sum()` guards to both methods, matching the existing pattern in `GammaUncertainty.validate`

Fixes #23

## Test plan

- [ ] `tests/distributions/test_weibull.py` — all existing tests pass
- [ ] `tests/distributions/test_extreme.py` — all existing tests pass
- [ ] Manual check: `WeibullUncertainty.validate` raises `InvalidParamsError` when `shape` or `scale` is NaN
- [ ] Manual check: `GeneralizedExtremeValueUncertainty.validate` raises `InvalidParamsError` when `scale` is NaN