### PR TITLE
Add UncertaintyType IntEnum for named distribution ID constants

### DIFF
--- a/src/stats_arrays/__init__.py
+++ b/src/stats_arrays/__init__.py
@@ -2,6 +2,7 @@ __version__ = "1.0.1"
 
 __all__ = (
     "BernoulliUncertainty",
+    "UncertaintyType",
     "BetaUncertainty",
     "BetaPERTUncertainty",
     "BoundedUncertaintyBase",
@@ -65,3 +66,4 @@ from stats_arrays.random import (
     RandomNumberGenerator,
 )
 from stats_arrays.uncertainty_choices import uncertainty_choices
+from stats_arrays.uncertainty_types import UncertaintyType

--- a/src/stats_arrays/uncertainty_choices.py
+++ b/src/stats_arrays/uncertainty_choices.py
@@ -42,7 +42,14 @@ DistributionType = TypeVar("DistributionType", bound=UncertaintyBase, covariant=
 
 
 class UncertaintyChoices(IterableABC[Type[UncertaintyBase]]):
-    """An container for uncertainty distributions."""
+    """A container for uncertainty distributions, keyed by integer ID.
+
+    Use :class:`stats_arrays.UncertaintyType` for named constants instead of
+    raw integer IDs::
+
+        uncertainty_choices[UncertaintyType.normal]   # NormalUncertainty
+        uncertainty_choices[3]                        # same thing
+    """
 
     def __init__(self):
         # Sorted by id

--- a/src/stats_arrays/uncertainty_types.py
+++ b/src/stats_arrays/uncertainty_types.py
@@ -1,0 +1,34 @@
+from enum import IntEnum
+
+
+class UncertaintyType(IntEnum):
+    """Integer enum of all built-in uncertainty distribution IDs.
+
+    Each member value equals the ``id`` attribute of the corresponding
+    distribution class and the integer stored in a params array's
+    ``uncertainty_type`` field, so all three forms are interchangeable::
+
+        UncertaintyType.normal          # 3  (enum member)
+        NormalUncertainty.id            # 3  (plain int)
+        params["uncertainty_type"]      # 3  (numpy uint8)
+
+        # All comparisons below are True
+        UncertaintyType.normal == 3
+        uncertainty_choices[UncertaintyType.normal] is NormalUncertainty
+        params["uncertainty_type"] == UncertaintyType.normal
+    """
+
+    undefined = 0
+    no_uncertainty = 1
+    lognormal = 2
+    normal = 3
+    uniform = 4
+    triangular = 5
+    bernoulli = 6
+    discrete_uniform = 7
+    weibull = 8
+    gamma = 9
+    beta = 10
+    generalized_extreme_value = 11
+    students_t = 12
+    beta_pert = 13

--- a/tests/test_uncertainty_types.py
+++ b/tests/test_uncertainty_types.py
@@ -1,0 +1,74 @@
+from stats_arrays import (
+    NormalUncertainty,
+    LognormalUncertainty,
+    UniformUncertainty,
+    TriangularUncertainty,
+    BernoulliUncertainty,
+    DiscreteUniform,
+    WeibullUncertainty,
+    GammaUncertainty,
+    BetaUncertainty,
+    GeneralizedExtremeValueUncertainty,
+    StudentsTUncertainty,
+    BetaPERTUncertainty,
+    NoUncertainty,
+    UndefinedUncertainty,
+    UncertaintyType,
+    uncertainty_choices,
+)
+
+
+DISTRIBUTION_IDS = [
+    (UncertaintyType.undefined,               UndefinedUncertainty),
+    (UncertaintyType.no_uncertainty,          NoUncertainty),
+    (UncertaintyType.lognormal,               LognormalUncertainty),
+    (UncertaintyType.normal,                  NormalUncertainty),
+    (UncertaintyType.uniform,                 UniformUncertainty),
+    (UncertaintyType.triangular,              TriangularUncertainty),
+    (UncertaintyType.bernoulli,               BernoulliUncertainty),
+    (UncertaintyType.discrete_uniform,        DiscreteUniform),
+    (UncertaintyType.weibull,                 WeibullUncertainty),
+    (UncertaintyType.gamma,                   GammaUncertainty),
+    (UncertaintyType.beta,                    BetaUncertainty),
+    (UncertaintyType.generalized_extreme_value, GeneralizedExtremeValueUncertainty),
+    (UncertaintyType.students_t,              StudentsTUncertainty),
+    (UncertaintyType.beta_pert,               BetaPERTUncertainty),
+]
+
+
+def test_enum_members_equal_distribution_ids():
+    """Each enum member value must match the corresponding class .id."""
+    for member, cls in DISTRIBUTION_IDS:
+        assert member == cls.id, f"{member.name} value {int(member)} != {cls.__name__}.id {cls.id}"
+
+
+def test_enum_members_are_ints():
+    """IntEnum members must compare equal to plain ints."""
+    assert UncertaintyType.normal == 3
+    assert UncertaintyType.lognormal == 2
+    assert UncertaintyType.beta_pert == 13
+
+
+def test_uncertainty_choices_lookup_by_enum():
+    """uncertainty_choices[enum_member] must return the correct class."""
+    for member, cls in DISTRIBUTION_IDS:
+        assert uncertainty_choices[member] is cls
+
+
+def test_numpy_comparison():
+    """Enum members must work in numpy array comparisons."""
+    params = NormalUncertainty.from_dicts(
+        {"loc": 1, "scale": 0.5, "uncertainty_type": 3},
+        {"loc": 2, "scale": 0.3, "uncertainty_type": 2},
+    )
+    mask = params["uncertainty_type"] == UncertaintyType.normal
+    assert mask.tolist() == [True, False]
+
+
+def test_all_distributions_covered():
+    """Every distribution registered in uncertainty_choices has an enum member."""
+    enum_values = {int(m) for m in UncertaintyType}
+    for dist in uncertainty_choices:
+        assert dist.id in enum_values, (
+            f"{dist.__name__} (id={dist.id}) has no UncertaintyType member"
+        )


### PR DESCRIPTION
## Summary

Adds `stats_arrays.UncertaintyType`, an `IntEnum` whose member values correspond to the integer `id` of each built-in distribution class.

Because `IntEnum` members *are* plain integers, **all existing code is unaffected** — this is a purely additive change.

```python
from stats_arrays import UncertaintyType, uncertainty_choices, NormalUncertainty

# All True — enum, class attribute, and raw int are interchangeable
UncertaintyType.normal == 3
UncertaintyType.normal == NormalUncertainty.id

# Works as a lookup key (UncertaintyChoices.__getitem__ takes int)
uncertainty_choices[UncertaintyType.normal] is NormalUncertainty

# Works in numpy comparisons against the uint8 uncertainty_type field
params["uncertainty_type"] == UncertaintyType.normal
```

## Members

| Member | Value | Distribution |
|---|---|---|
| `undefined` | 0 | `UndefinedUncertainty` |
| `no_uncertainty` | 1 | `NoUncertainty` |
| `lognormal` | 2 | `LognormalUncertainty` |
| `normal` | 3 | `NormalUncertainty` |
| `uniform` | 4 | `UniformUncertainty` |
| `triangular` | 5 | `TriangularUncertainty` |
| `bernoulli` | 6 | `BernoulliUncertainty` |
| `discrete_uniform` | 7 | `DiscreteUniform` |
| `weibull` | 8 | `WeibullUncertainty` |
| `gamma` | 9 | `GammaUncertainty` |
| `beta` | 10 | `BetaUncertainty` |
| `generalized_extreme_value` | 11 | `GeneralizedExtremeValueUncertainty` |
| `students_t` | 12 | `StudentsTUncertainty` |
| `beta_pert` | 13 | `BetaPERTUncertainty` |

## Design notes

- The enum lives in a standalone `uncertainty_types.py` module with no imports from the distributions package, avoiding any circular import risk
- Distribution class `.id` attributes are left as plain `int` — updating them is unnecessary since `IntEnum` members compare equal to their int values anyway
- `UncertaintyChoices` docstring now points users to `UncertaintyType`

Relates to #5

## Test plan

- [ ] Full suite: 206 passed, 0 failures
- [ ] `tests/test_uncertainty_types.py` — 5 new tests covering: member/class ID agreement, int equality, `uncertainty_choices` lookup, numpy comparison, and coverage of all registered distributions