### PR TITLE
Fix TriangularUncertainty.pdf default-xs branch

### DIFF
--- a/src/stats_arrays/distributions/geometric.py
+++ b/src/stats_arrays/distributions/geometric.py
@@ -153,17 +153,13 @@ class TriangularUncertainty(BoundedUncertaintyBase):
     def pdf(
         cls, params: ParamsArray, xs: Optional[npt.NDArray] = None
     ) -> tuple[npt.NDArray, npt.NDArray]:
+        adjusted_means, scale = cls.rescale_to_unitary_interval(params)
         if xs is None:
-            lower = params["minimum"]
-            upper = params["maximum"]
-            mode = params["loc"]
-            if not mode:
-                mode = (upper + lower) / 2
-            xs = np.array([float(x.flat[0]) for x in (lower, mode, upper)])
-            ys = np.array([0, float(((mode - lower) / (upper - lower)).flat[0]), 0])
-        else:
-            adjusted_means, scale = cls.rescale_to_unitary_interval(params)
-            adj_xs = (xs - params["minimum"]) / scale
-            ys_0_1_interval = stats.triang.pdf(adj_xs, adjusted_means)
-            ys = ys_0_1_interval / scale
-        return xs, ys
+            xs = np.linspace(
+                float(params["minimum"].flat[0]),
+                float(params["maximum"].flat[0]),
+                cls.default_number_points_in_pdf,
+            )
+        adj_xs = (xs - params["minimum"]) / scale
+        ys = stats.triang.pdf(adj_xs, adjusted_means) / scale
+        return xs, ys.ravel()

--- a/tests/distributions/test_triangular.py
+++ b/tests/distributions/test_triangular.py
@@ -150,10 +150,15 @@ def test_triangular_statistics(biased_params_1d):
 
 
 def test_triangular_pdf_without_xs(biased_params_1d):
-    """Test PDF calculation without specifying xs."""
-    xs, ys = TriangularUncertainty.pdf(biased_params_1d)
-    assert np.allclose(np.array([1, 3, 4]), xs)
-    assert np.allclose(np.array([0, 0.66666669, 0]), ys)
+    """Test PDF calculation without specifying xs returns 200 correct points."""
+    xs, _ = TriangularUncertainty.pdf(biased_params_1d)
+    assert len(xs) == 200
+    assert xs[0] == pytest.approx(1.0)
+    assert xs[-1] == pytest.approx(4.0)
+    # Verify correct values at specific interior points using explicit xs
+    xs_check = np.array([1.0, 2.0, 3.0, 4.0])
+    _, ys_check = TriangularUncertainty.pdf(biased_params_1d, xs_check)
+    assert np.allclose(ys_check, np.array([0.0, 1 / 3, 2 / 3, 0.0]))
 
 
 def test_triangular_pdf_with_xs(biased_params_1d):
@@ -165,16 +170,17 @@ def test_triangular_pdf_with_xs(biased_params_1d):
 
 
 def test_triangular_pdf_with_zero_mode(make_params_array):
-    """Test PDF calculation when mode is zero (uses default midpoint)."""
+    """Test PDF calculation when mode is zero is handled correctly."""
     params = make_params_array(1)
     params["minimum"] = 0.0
     params["maximum"] = 4.0
-    params["loc"] = 0.0  # Zero mode
+    params["loc"] = 0.0  # Zero mode — degenerate triangle, peaks at the left
 
     xs, ys = TriangularUncertainty.pdf(params)
 
-    # Should default to midpoint when mode is 0
-    # Expected xs: [0, 2, 4] (lower, midpoint, upper)
-    assert np.allclose(np.array([0, 2, 4]), xs)
-    # PDF at endpoints should be 0, at midpoint should be 1/(upper-lower) = 1/4 = 0.25
-    assert np.allclose(np.array([0, 0.5, 0]), ys, rtol=1e-6)
+    assert len(xs) == 200
+    assert xs[0] == pytest.approx(0.0)
+    assert xs[-1] == pytest.approx(4.0)
+    # c=0: right-angled triangle peaking at minimum; peak height = 2/(upper-lower) = 0.5
+    assert ys[0] == pytest.approx(0.5, rel=1e-5)
+    assert ys[-1] == pytest.approx(0.0, abs=1e-10)


### PR DESCRIPTION
## Summary

Fixes three bugs in the default-xs (no `xs` argument) code path of `TriangularUncertainty.pdf`:

- **#31** — `if not mode` treated `mode=0.0` as falsy, silently replacing the actual mode with the midpoint of the distribution
- **#32** — Peak height formula `(mode - lower) / (upper - lower)` returned the `c` parameter (normalized mode position), not the true PDF height `2 / (upper - lower)`. For example, with lower=0, mode=3, upper=10 it returned 0.3 instead of the correct 0.2.
- **#33** — When `mode == minimum` or `mode == maximum`, the 3-point `xs` array had duplicate entries (e.g. `[1, 1, 5]`), and the peak `ys` was 0 — a completely degenerate result.

The fix replaces the hand-rolled 3-point branch with a `np.linspace` + scipy path, matching how the explicit-xs branch already worked. Two tests that asserted the old incorrect behavior are updated.

## Test plan

- [ ] `tests/distributions/test_triangular.py` — all 10 tests pass
- [ ] Full suite — 201 passed, 6 skipped
- [ ] Manually verified: mode==min, mode==max, mode==0.0, and general case all produce correct peak heights and 200-point output