### PR TITLE
Fix CI not running on subsequent PR commits

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -17,7 +17,7 @@ on:
       - ".gitignore"
   pull_request:
     branches: [main, develop]
-    types: [opened, reopened] # excludes syncronize to avoid redundant trigger from commits on PRs
+    types: [opened, reopened, synchronize]
     paths-ignore:
       - "**.md"
       - "**.bib"


### PR DESCRIPTION
## Summary

- The `pull_request` trigger in `python-test.yml` was missing the `synchronize` event type
- `synchronize` is what GitHub fires when new commits are pushed to an existing PR
- Without it, CI only ran when a PR was first opened or reopened, but never on follow-up commits

## Fix

Added `synchronize` to the `types` list on the `pull_request` trigger.

## Test plan

- [ ] Open a PR and confirm CI runs on open
- [ ] Push a follow-up commit to the PR and confirm CI runs again