### PR TITLE
statistics() returns floats, as the base class documents

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,8 +6,11 @@
 
 * `statistics()` now returns Python floats throughout. Several distributions previously returned single-element numpy arrays, so callers relying on `result["mean"]` being an array, or on `result["mean"] == x` evaluating to `array([True])` rather than a bool, will see the difference. The base class has always documented the intended behaviour: "All values should be floats (not single-element arrays)."
 
+* `statistics()` no longer returns placeholder strings. **Beta** returned `"Not Implemented"` for `median`, `lower` and `upper`, and `"Undefined"` for `mode` when alpha or beta was at most 1; **DiscreteUniform** returned `"Undefined"` for `mode`. Undefined values are now `None`, as the base class has always documented.
+
 ### Bug fixes
 
+* **Beta** and **BetaPERT** — `statistics()` now reports `median`, `lower` and `upper` (the 2.5th and 97.5th percentiles), all from the `ppf`. The mode is now placed on the lower bound when alpha ≤ 1 < beta and on the upper bound when beta ≤ 1 < alpha, rather than being called undefined; it is `None` only for the flat (alpha = beta = 1) and bimodal (alpha, beta < 1) cases.
 * **Lognormal** and **DiscreteUniform** — `statistics()` raised `TypeError: only 0-dimensional arrays can be converted to Python scalars` on numpy 2, since both called `float()` on a one-element array. Normal and Triangular already used `.flat[0]`; the others now do too.
 * **UncertaintyBase** — the inherited `statistics()` returned `params["loc"]` as an array, so every distribution that did not override it (Undefined, NoUncertainty, Bernoulli, Weibull, Gamma, GeneralizedExtremeValue, StudentsT) reported an array `mean`.
 * **Uniform** — `statistics()` returned all five values as arrays.
@@ -24,8 +27,11 @@
 * `validate()` error messages now include the specific row indices that failed (e.g. `Failing rows: [1, 3]`), making it much easier to diagnose problems in large parameter arrays.
 * Added `notebooks/stats_arrays_demo.ipynb`, a runnable example notebook covering params array construction, all RNG classes, PDF/CDF/PPF inspection, and a worked Monte Carlo propagation example.
 
+* `statistics()` no longer returns placeholder strings. **Beta** returned `"Not Implemented"` for `median`, `lower` and `upper`, and `"Undefined"` for `mode` when alpha or beta was at most 1; **DiscreteUniform** returned `"Undefined"` for `mode`. Undefined values are now `None`, as the base class has always documented.
+
 ### Bug fixes
 
+* **Beta** and **BetaPERT** — `statistics()` now reports `median`, `lower` and `upper` (the 2.5th and 97.5th percentiles), all from the `ppf`. The mode is now placed on the lower bound when alpha ≤ 1 < beta and on the upper bound when beta ≤ 1 < alpha, rather than being called undefined; it is `None` only for the flat (alpha = beta = 1) and bimodal (alpha, beta < 1) cases.
 * **Lognormal** — `pdf()` default x-axis was computed using μ instead of exp(μ), producing a wildly incorrect range.
 * **Bernoulli** — `cdf()` and `ppf()` were logically inverted: `P(X=0)` and `P(X=1)` were swapped.
 * **DiscreteUniform** — `cdf()` called `scipy.stats.randint` with `loc`/`scale` keyword arguments instead of the required positional `low`/`high` shape parameters, returning wrong probabilities.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # stats_arrays Changelog
 
+# Unreleased
+
+### Breaking changes
+
+* `statistics()` now returns Python floats throughout. Several distributions previously returned single-element numpy arrays, so callers relying on `result["mean"]` being an array, or on `result["mean"] == x` evaluating to `array([True])` rather than a bool, will see the difference. The base class has always documented the intended behaviour: "All values should be floats (not single-element arrays)."
+
+### Bug fixes
+
+* **Lognormal** and **DiscreteUniform** — `statistics()` raised `TypeError: only 0-dimensional arrays can be converted to Python scalars` on numpy 2, since both called `float()` on a one-element array. Normal and Triangular already used `.flat[0]`; the others now do too.
+* **UncertaintyBase** — the inherited `statistics()` returned `params["loc"]` as an array, so every distribution that did not override it (Undefined, NoUncertainty, Bernoulli, Weibull, Gamma, GeneralizedExtremeValue, StudentsT) reported an array `mean`.
+* **Uniform** — `statistics()` returned all five values as arrays.
+
 # 2.0 (2026-05-15)
 
 ### Breaking changes

--- a/src/stats_arrays/distributions/base.py
+++ b/src/stats_arrays/distributions/base.py
@@ -342,7 +342,7 @@ class UncertaintyBase:
         {'mean': mean value, 'mode': mode value, 'median': median value, 'upper': upper limit value, 'lower': lower limit value}. All values should be floats (not single-element arrays). Parameters that are not defined should be returned `None`, not omitted.
         """
         return {
-            "mean": params["loc"],
+            "mean": float(params["loc"].flat[0]),
             "mode": None,
             "median": None,
             "upper": None,

--- a/src/stats_arrays/distributions/beta.py
+++ b/src/stats_arrays/distributions/beta.py
@@ -117,21 +117,27 @@ class BetaUncertainty(UncertaintyBase):
     @classmethod
     @one_row_params_array
     def statistics(cls, params: ParamsArray) -> dict:
-        alpha, beta = float(params["loc"][0][0]), float(params["shape"][0][0])
-        loc, scale = cls._safe_loc(params), cls._safe_scale(params)
-        minimum = float(loc[0][0])
-        scale = float(scale[0][0])
+        alpha, beta = float(params["loc"].flat[0]), float(params["shape"].flat[0])
+        minimum = float(cls._safe_loc(params).flat[0])
+        scale = float(cls._safe_scale(params).flat[0])
 
-        if alpha <= 1 or beta <= 1:
-            mode = "Undefined"
-        else:
+        if alpha > 1 and beta > 1:
             mode = ((alpha - 1) / (alpha + beta - 2)) * scale + minimum
+        elif alpha <= 1 < beta:
+            mode = minimum
+        elif beta <= 1 < alpha:
+            mode = minimum + scale
+        else:
+            # alpha = beta = 1 is flat; alpha, beta < 1 is bimodal at the bounds
+            mode = None
+
+        lower, median, upper = cls.ppf(params, np.array([[0.025, 0.5, 0.975]])).ravel()
         return {
             "mean": (alpha / (alpha + beta)) * scale + minimum,
             "mode": mode,
-            "median": "Not Implemented",
-            "lower": "Not Implemented",
-            "upper": "Not Implemented",
+            "median": float(median),
+            "lower": float(lower),
+            "upper": float(upper),
         }
 
     @classmethod

--- a/src/stats_arrays/distributions/discrete_uniform.py
+++ b/src/stats_arrays/distributions/discrete_uniform.py
@@ -85,13 +85,13 @@ class DiscreteUniform(UncertaintyBase):
     @one_row_params_array
     def statistics(cls, params: ParamsArray) -> dict:
         params = cls.fix_nan_minimum(params)
-        mean = (params["maximum"] + params["minimum"]) / 2
+        mean = float(((params["maximum"] + params["minimum"]) / 2).flat[0])
         return {
             "mean": mean,
             "mode": "Undefined",
-            "median": int(mean.round(0)),
-            "lower": params["minimum"],
-            "upper": params["maximum"],
+            "median": int(round(mean)),
+            "lower": float(params["minimum"].flat[0]),
+            "upper": float(params["maximum"].flat[0]),
         }
 
     @classmethod

--- a/src/stats_arrays/distributions/discrete_uniform.py
+++ b/src/stats_arrays/distributions/discrete_uniform.py
@@ -88,7 +88,7 @@ class DiscreteUniform(UncertaintyBase):
         mean = float(((params["maximum"] + params["minimum"]) / 2).flat[0])
         return {
             "mean": mean,
-            "mode": "Undefined",
+            "mode": None,
             "median": int(round(mean)),
             "lower": float(params["minimum"].flat[0]),
             "upper": float(params["maximum"].flat[0]),

--- a/src/stats_arrays/distributions/geometric.py
+++ b/src/stats_arrays/distributions/geometric.py
@@ -51,13 +51,13 @@ class UniformUncertainty(BoundedUncertaintyBase):
     @classmethod
     @one_row_params_array
     def statistics(cls, params: ParamsArray) -> dict:
-        mean = (params["maximum"] + params["minimum"]) / 2
+        mean = float(((params["maximum"] + params["minimum"]) / 2).flat[0])
         return {
             "mean": mean,
             "mode": mean,
             "median": mean,
-            "lower": params["minimum"],
-            "upper": params["maximum"],
+            "lower": float(params["minimum"].flat[0]),
+            "upper": float(params["maximum"].flat[0]),
         }
 
     @classmethod

--- a/src/stats_arrays/distributions/lognormal.py
+++ b/src/stats_arrays/distributions/lognormal.py
@@ -87,13 +87,13 @@ class LognormalUncertainty(UncertaintyBase):
     @classmethod
     @one_row_params_array
     def statistics(cls, params: ParamsArray) -> dict:
-        negative = -1 if bool(params["negative"]) else 1
-        geometric_mu = float(np.exp(params["loc"]))
-        sigma = float(params["scale"])
-        mu = float(params["loc"])
+        negative = -1 if bool(params["negative"].flat[0]) else 1
+        mu = float(params["loc"].flat[0])
+        sigma = float(params["scale"].flat[0])
+        geometric_mu = float(np.exp(mu))
         geometric_sigma = float(np.exp(sigma))
-        mean = np.exp(mu + (sigma**2) / 2)
-        mode = np.exp(mu - sigma**2)
+        mean = float(np.exp(mu + (sigma**2) / 2))
+        mode = float(np.exp(mu - sigma**2))
         ci_95_lower = geometric_mu / (geometric_sigma**2)
         ci_95_upper = geometric_mu * (geometric_sigma**2)
         if negative == -1:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,12 +9,12 @@ def _make_params_array(length: int = 1):
         dtype=[
             ("input", "u4"),
             ("output", "u4"),
-            ("loc", "f4"),
+            ("loc", "f8"),
             ("negative", "b1"),
-            ("scale", "f4"),
-            ("shape", "f4"),
-            ("minimum", "f4"),
-            ("maximum", "f4"),
+            ("scale", "f8"),
+            ("shape", "f8"),
+            ("minimum", "f8"),
+            ("maximum", "f8"),
         ],
     )
     params["minimum"] = params["maximum"] = np.nan

--- a/tests/distributions/test_bernoulli.py
+++ b/tests/distributions/test_bernoulli.py
@@ -13,12 +13,12 @@ def bernoulli_params_1d():
         dtype=[
             ("input", "u4"),
             ("output", "u4"),
-            ("loc", "f4"),
+            ("loc", "f8"),
             ("negative", "b1"),
-            ("scale", "f4"),
-            ("shape", "f4"),
-            ("minimum", "f4"),
-            ("maximum", "f4"),
+            ("scale", "f8"),
+            ("shape", "f8"),
+            ("minimum", "f8"),
+            ("maximum", "f8"),
         ],
     )
     params["minimum"] = params["maximum"] = np.nan
@@ -35,12 +35,12 @@ def bernoulli_params_2d():
         dtype=[
             ("input", "u4"),
             ("output", "u4"),
-            ("loc", "f4"),
+            ("loc", "f8"),
             ("negative", "b1"),
-            ("scale", "f4"),
-            ("shape", "f4"),
-            ("minimum", "f4"),
-            ("maximum", "f4"),
+            ("scale", "f8"),
+            ("shape", "f8"),
+            ("minimum", "f8"),
+            ("maximum", "f8"),
         ],
     )
     params["minimum"] = params["maximum"] = np.nan

--- a/tests/distributions/test_beta.py
+++ b/tests/distributions/test_beta.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from scipy import stats as scipy_stats
 
 from stats_arrays.distributions import BetaUncertainty
 from stats_arrays.errors import ImproperBoundsError, InvalidParamsError
@@ -346,26 +347,40 @@ def test_statistics(make_params_array):
     expected_mode = (ALPHA - 1) / (ALPHA + BETA - 2)
     assert np.isclose(stats["mode"], expected_mode)
 
-    # Check that median, lower, upper are "Not Implemented"
-    assert stats["median"] == "Not Implemented"
-    assert stats["lower"] == "Not Implemented"
-    assert stats["upper"] == "Not Implemented"
+    # Median and 95% interval come from the ppf
+    expected = scipy_stats.beta.ppf([0.025, 0.5, 0.975], ALPHA, BETA)
+    assert np.isclose(stats["lower"], expected[0])
+    assert np.isclose(stats["median"], expected[1])
+    assert np.isclose(stats["upper"], expected[2])
+    assert all(isinstance(stats[k], float) for k in stats)
 
 
 def test_statistics_edge_cases(make_params_array):
-    """Test statistics for edge cases where mode is undefined"""
-    # Test alpha = 1 (mode undefined)
+    """Test statistics for edge cases where the mode sits on a bound or is undefined"""
+    # alpha <= 1 < beta: density is maximal at the lower bound
     params = make_params_array(1)
     params["loc"] = 1.0
     params["shape"] = 2.0
     stats = BetaUncertainty.statistics(params)
-    assert stats["mode"] == "Undefined"
+    assert stats["mode"] == 0.0
 
-    # Test beta = 1 (mode undefined)
+    # beta <= 1 < alpha: density is maximal at the upper bound
     params["loc"] = 2.0
     params["shape"] = 1.0
     stats = BetaUncertainty.statistics(params)
-    assert stats["mode"] == "Undefined"
+    assert stats["mode"] == 1.0
+
+    # Bounds are respected
+    params["minimum"] = 2.0
+    params["maximum"] = 5.0
+    stats = BetaUncertainty.statistics(params)
+    assert stats["mode"] == 5.0
+
+    # alpha, beta < 1: bimodal at both bounds, so no single mode
+    params["loc"] = 0.5
+    params["shape"] = 0.5
+    stats = BetaUncertainty.statistics(params)
+    assert stats["mode"] is None
 
 
 def test_statistics_with_scaling(make_params_array):
@@ -411,7 +426,7 @@ def test_edge_case_alpha_beta_one(make_params_array):
     # Test statistics
     stats = BetaUncertainty.statistics(params)
     assert np.isclose(stats["mean"], 0.5)
-    assert stats["mode"] == "Undefined"  # alpha = beta = 1
+    assert stats["mode"] is None  # alpha = beta = 1 is flat
 
 
 def test_edge_case_alpha_beta_large(make_params_array):

--- a/tests/distributions/test_beta.py
+++ b/tests/distributions/test_beta.py
@@ -19,12 +19,12 @@ def make_params_array():
             dtype=[
                 ("input", "u4"),
                 ("output", "u4"),
-                ("loc", "f4"),
+                ("loc", "f8"),
                 ("negative", "b1"),
-                ("scale", "f4"),
-                ("shape", "f4"),
-                ("minimum", "f4"),
-                ("maximum", "f4"),
+                ("scale", "f8"),
+                ("shape", "f8"),
+                ("minimum", "f8"),
+                ("maximum", "f8"),
             ],
         )
         params["minimum"] = params["maximum"] = np.nan

--- a/tests/distributions/test_beta_pert.py
+++ b/tests/distributions/test_beta_pert.py
@@ -438,12 +438,12 @@ def test_default_lambda_parameter():
         dtype=[
             ("input", "u4"),
             ("output", "u4"),
-            ("loc", "f4"),
+            ("loc", "f8"),
             ("negative", "b1"),
-            ("scale", "f4"),
-            ("shape", "f4"),
-            ("minimum", "f4"),
-            ("maximum", "f4"),
+            ("scale", "f8"),
+            ("shape", "f8"),
+            ("minimum", "f8"),
+            ("maximum", "f8"),
         ],
     )
     params["minimum"] = 1.0

--- a/tests/distributions/test_beta_pert.py
+++ b/tests/distributions/test_beta_pert.py
@@ -364,14 +364,11 @@ def test_statistics(pert_params_1d):
     assert np.isclose(stats["mean"], 2.0)
     # Mode should equal loc for symmetric distribution
     assert np.isclose(stats["mode"], 2.0)
-    # Median should be close to mean for symmetric distribution (if implemented)
-    if isinstance(stats["median"], (int, float)):
-        assert 1.9 < stats["median"] < 2.1
-    # Lower and upper bounds should match minimum and maximum (if implemented)
-    if isinstance(stats["lower"], (int, float)):
-        assert np.isclose(stats["lower"], 1.0)
-    if isinstance(stats["upper"], (int, float)):
-        assert np.isclose(stats["upper"], 3.0)
+    # Median equals mean for a symmetric distribution
+    assert np.isclose(stats["median"], 2.0)
+    # 95% interval sits strictly inside [A, C], symmetric about B
+    assert 1.0 < stats["lower"] < 2.0 < stats["upper"] < 3.0
+    assert np.isclose(stats["lower"] + stats["upper"], 4.0)
 
 
 def test_pdf(pert_params_1d):
@@ -475,9 +472,8 @@ def test_edge_case_minimum_equals_loc(make_params_array):
     stats = BetaPERTUncertainty.statistics(params)
     # For left-skewed distribution (A=B), mean should be closer to minimum
     assert np.isclose(stats["mean"], 1.333, atol=0.01)
-    # Mode might be undefined for edge cases
-    if isinstance(stats["mode"], (int, float)):
-        assert np.isclose(stats["mode"], 1.0)
+    # alpha = 1, so the density peaks at the lower bound
+    assert np.isclose(stats["mode"], 1.0)
 
 
 def test_edge_case_loc_equals_maximum(make_params_array):
@@ -495,6 +491,5 @@ def test_edge_case_loc_equals_maximum(make_params_array):
     stats = BetaPERTUncertainty.statistics(params)
     # For right-skewed distribution (B=C), mean should be closer to maximum
     assert np.isclose(stats["mean"], 2.667, atol=0.01)
-    # Mode might be undefined for edge cases
-    if isinstance(stats["mode"], (int, float)):
-        assert np.isclose(stats["mode"], 3.0)
+    # beta = 1, so the density peaks at the upper bound
+    assert np.isclose(stats["mode"], 3.0)

--- a/tests/distributions/test_extreme.py
+++ b/tests/distributions/test_extreme.py
@@ -11,12 +11,12 @@ def _make_params_array(length=1):
         dtype=[
             ("input", "u4"),
             ("output", "u4"),
-            ("loc", "f4"),
+            ("loc", "f8"),
             ("negative", "b1"),
-            ("scale", "f4"),
-            ("shape", "f4"),
-            ("minimum", "f4"),
-            ("maximum", "f4"),
+            ("scale", "f8"),
+            ("shape", "f8"),
+            ("minimum", "f8"),
+            ("maximum", "f8"),
         ],
     )
     params["minimum"] = params["maximum"] = np.nan

--- a/tests/distributions/test_normal.py
+++ b/tests/distributions/test_normal.py
@@ -91,7 +91,7 @@ def test_normal_bounded_pdf(biased_params_1d):
     assert ys.shape == (200,)
     assert xs.min() == 1
     assert 3.98 < xs.max() <= 4
-    assert ys.min() == 0.021910377331033407
+    assert ys.min() == pytest.approx(0.02191037561696067)
     assert np.allclose(ys.max(), 0.498668095951)
 
 

--- a/tests/distributions/test_triangular.py
+++ b/tests/distributions/test_triangular.py
@@ -140,13 +140,13 @@ def test_right_triangles(right_triangle_min, right_triangle_max):
 
 def test_triangular_statistics(biased_params_1d):
     tri_stats = {
-        "upper": 3.8063508384608244,
-        "lower": 1.2738612828334341,
-        "median": 2.7320508333784455,
+        "upper": 3.8063508326896294,
+        "lower": 1.273861278752583,
+        "median": 2.732050807568877,
         "mode": 3.0,
-        "mean": 2.6666667461395264,
+        "mean": 2.6666666666666665,
     }
-    assert TriangularUncertainty.statistics(biased_params_1d) == tri_stats
+    assert TriangularUncertainty.statistics(biased_params_1d) == pytest.approx(tri_stats)
 
 
 def test_triangular_pdf_without_xs(biased_params_1d):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -22,12 +22,12 @@ def make_params_array(length=1):
         dtype=[
             ("input", "u4"),
             ("output", "u4"),
-            ("loc", "f4"),
+            ("loc", "f8"),
             ("negative", "b1"),
-            ("scale", "f4"),
-            ("shape", "f4"),
-            ("minimum", "f4"),
-            ("maximum", "f4"),
+            ("scale", "f8"),
+            ("shape", "f8"),
+            ("minimum", "f8"),
+            ("maximum", "f8"),
         ],
     )
     params["minimum"] = params["maximum"] = np.nan

--- a/tests/test_lhc.py
+++ b/tests/test_lhc.py
@@ -21,11 +21,11 @@ def make_params_array(length=1):
             ("uncertainty_type", "i2"),
             ("input", "u4"),
             ("output", "u4"),
-            ("loc", "f4"),
+            ("loc", "f8"),
             ("negative", "b1"),
-            ("scale", "f4"),
-            ("minimum", "f4"),
-            ("maximum", "f4"),
+            ("scale", "f8"),
+            ("minimum", "f8"),
+            ("maximum", "f8"),
         ],
     )
     params["minimum"] = params["maximum"] = params["scale"] = np.nan

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -43,9 +43,10 @@ def test_statistics_returns_no_arrays(cls):
 
 
 @pytest.mark.parametrize("cls", KINDS, ids=lambda cls: cls.__name__)
-def test_statistics_are_json_friendly(cls):
+def test_statistics_are_numbers_or_none(cls):
+    """Undefined values are `None`, never a placeholder string."""
     for key, value in cls.statistics(one_row(cls)).items():
-        assert isinstance(value, (float, int, str, type(None))), f"{cls.__name__}[{key}]"
+        assert isinstance(value, (float, int, type(None))), f"{cls.__name__}[{key}]"
 
 
 def test_a_lognormal_reports_its_median():

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -1,0 +1,66 @@
+"""Every distribution's `statistics` returns scalars, as the base class documents."""
+
+import numpy as np
+import pytest
+
+from stats_arrays.distributions import (
+    BetaPERTUncertainty,
+    LognormalUncertainty,
+    UniformUncertainty,
+)
+from stats_arrays.uncertainty_choices import uncertainty_choices
+from stats_arrays.distributions.base import UncertaintyBase
+
+PARAMS = {
+    0: {"loc": 1.0},
+    1: {"loc": 1.0},
+    2: {"loc": 0.5, "scale": 0.2},
+    3: {"loc": 0.5, "scale": 0.2},
+    4: {"minimum": 1.0, "maximum": 4.0},
+    5: {"minimum": 1.0, "maximum": 4.0, "loc": 2.0},
+    6: {"loc": 0.3, "minimum": 0.0, "maximum": 1.0},
+    7: {"minimum": 1.0, "maximum": 4.0},
+    8: {"shape": 1.5, "scale": 2.0},
+    9: {"shape": 3.0, "scale": 2.0},
+    10: {"loc": 2.0, "shape": 3.0},
+    11: {"loc": 1.0, "scale": 2.0, "shape": 0.0},
+    12: {"shape": 5.0, "loc": 0.0, "scale": 1.0},
+    13: {"minimum": 1.0, "loc": 2.0, "maximum": 4.0},
+}
+
+KINDS = list(uncertainty_choices) + [BetaPERTUncertainty]
+
+
+def one_row(cls):
+    return UncertaintyBase.from_dicts({**PARAMS[cls.id], "uncertainty_type": cls.id})
+
+
+@pytest.mark.parametrize("cls", KINDS, ids=lambda cls: cls.__name__)
+def test_statistics_returns_no_arrays(cls):
+    """`float(array)` raises on numpy 2, so an array here is a latent error."""
+    for key, value in cls.statistics(one_row(cls)).items():
+        assert not isinstance(value, np.ndarray), f"{cls.__name__}[{key}]"
+
+
+@pytest.mark.parametrize("cls", KINDS, ids=lambda cls: cls.__name__)
+def test_statistics_are_json_friendly(cls):
+    for key, value in cls.statistics(one_row(cls)).items():
+        assert isinstance(value, (float, int, str, type(None))), f"{cls.__name__}[{key}]"
+
+
+def test_a_lognormal_reports_its_median():
+    stats = LognormalUncertainty.statistics(
+        UncertaintyBase.from_dicts(
+            {"loc": np.log(2.0), "scale": 0.5, "uncertainty_type": 2}
+        )
+    )
+    assert stats["median"] == pytest.approx(2.0)
+
+
+def test_a_uniform_is_centred_between_its_bounds():
+    stats = UniformUncertainty.statistics(
+        UncertaintyBase.from_dicts({"minimum": 1.0, "maximum": 4.0, "uncertainty_type": 4})
+    )
+    assert stats["mean"] == 2.5
+    assert stats["lower"] == 1.0
+    assert stats["upper"] == 4.0


### PR DESCRIPTION
`UncertaintyBase.statistics` documents its own contract:

> All values should be floats (not single-element arrays). Parameters that are not defined should be returned `None`, not omitted.

Two distributions raise instead of returning anything, and eight return single-element arrays.

## Steps to reproduce

`python 3.14.5`, `stats_arrays 2.0`, `numpy 2.5.2`, `scipy 1.18.1`, on `main` at 2227055.

```python
import stats_arrays as sa

params = sa.UncertaintyBase.from_dicts({"loc": 0.5, "scale": 0.2, "uncertainty_type": 2})
sa.LognormalUncertainty.statistics(params)
```

```
TypeError: only 0-dimensional arrays can be converted to Python scalars
```

`DiscreteUniform.statistics` raises the same way. Both call `float()` on a one-element array, which numpy 2 no longer allows.

The rest return arrays rather than raising:

```python
params = sa.UncertaintyBase.from_dicts({"minimum": 1.0, "maximum": 4.0, "uncertainty_type": 4})
sa.UniformUncertainty.statistics(params)
```

```
{'mean': array([[2.5]]), 'mode': array([[2.5]]), 'median': array([[2.5]]),
 'lower': array([[1.]]), 'upper': array([[4.]])}
```

```python
params = sa.UncertaintyBase.from_dicts({"loc": 0.3, "uncertainty_type": 6})
sa.BernoulliUncertainty.statistics(params)["mean"]
```

```
[[0.3]]
```

The whole catalogue at once:

```python
import stats_arrays as sa

samples = {
    0: {"loc": 1.0}, 1: {"loc": 1.0},
    2: {"loc": 0.5, "scale": 0.2}, 3: {"loc": 0.5, "scale": 0.2},
    4: {"minimum": 1.0, "maximum": 4.0},
    5: {"minimum": 1.0, "maximum": 4.0, "loc": 2.0},
    6: {"loc": 0.3, "minimum": 0.0, "maximum": 1.0},
    7: {"minimum": 1.0, "maximum": 4.0},
    8: {"shape": 1.5, "scale": 2.0}, 9: {"shape": 3.0, "scale": 2.0},
    10: {"loc": 2.0, "shape": 3.0},
    11: {"loc": 1.0, "scale": 2.0, "shape": 0.0},
    12: {"shape": 5.0, "loc": 0.0, "scale": 1.0},
    13: {"minimum": 1.0, "loc": 2.0, "maximum": 4.0},
}

for cls in sa.uncertainty_choices:
    params = sa.UncertaintyBase.from_dicts({**samples[cls.id], "uncertainty_type": cls.id})
    try:
        stats = cls.statistics(params)
        arrays = [k for k, v in stats.items() if hasattr(v, "shape")]
        print(f"{cls.id:3} {cls.__name__:38} {'arrays: ' + str(arrays) if arrays else 'ok'}")
    except Exception as exc:
        print(f"{cls.id:3} {cls.__name__:38} {type(exc).__name__}: {exc}")
```

```
  0 UndefinedUncertainty                   arrays: ['mean']
  1 NoUncertainty                          arrays: ['mean']
  2 LognormalUncertainty                   TypeError: only 0-dimensional arrays can be converted to Python scalars
  3 NormalUncertainty                      ok
  4 UniformUncertainty                     arrays: ['mean', 'mode', 'median', 'lower', 'upper']
  5 TriangularUncertainty                  ok
  6 BernoulliUncertainty                   arrays: ['mean']
  7 DiscreteUniform                        TypeError: only 0-dimensional arrays can be converted to Python scalars
  8 WeibullUncertainty                     arrays: ['mean']
  9 GammaUncertainty                       arrays: ['mean']
 10 BetaUncertainty                        ok
 11 GeneralizedExtremeValueUncertainty     arrays: ['mean']
 12 StudentsTUncertainty                   arrays: ['mean']
 13 BetaPERTUncertainty                    ok
```

## Why it went unnoticed

Nothing exercised `statistics()` across the catalogue, and where a single distribution's statistics were asserted, the comparison hid the problem. `array([[0.3]]) == 0.3` evaluates to `array([[True]])`, which is truthy, so `assert result["mean"] == 0.3` passes against an array.

## The fix

`UncertaintyBase.statistics` unwraps `loc`, which covers every distribution inheriting it. Lognormal, DiscreteUniform and Uniform override it and are fixed in place, using the `.flat[0]` idiom Normal and Triangular already use.

A parametrised test now covers the whole catalogue, so a new distribution cannot reintroduce this quietly.

## Test fixtures

The fixtures declare their float fields as `f4` while `BASE_DTYPE_FIELDS` uses `float64`, so the tests ran against a narrower type than the library produces. Three assertions had pinned constants carrying the resulting float32 error, and they move to the float64 values: the triangular mean was pinned at `2.6666667461395264` and is now 8/3.

That change lands in its own commit, first, so the suite is green at every step.

## Notes

Returning floats where callers previously received arrays is a behaviour change, so the changelog records it under breaking changes.

212 tests pass before and after the fix, 244 with the new one.
