### PR TITLE
DiscreteUniform statistics: mean and median reflect the exclusive maximum

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 ### Bug fixes
 
+* **DiscreteUniform** — `statistics()` reported a `mean` of `(minimum + maximum) / 2` and a `median` of that value rounded to an integer. The support excludes `maximum`, so both were off by one half: for the values 5 to 9 the mean was 7.5 and the median 8, where both are 7. Both now equal `(minimum + maximum - 1) / 2`, matching `scipy.stats.randint`, and the median is a float that lands on a half-integer for an even count of values.
 * **Beta** and **BetaPERT** — `statistics()` now reports `median`, `lower` and `upper` (the 2.5th and 97.5th percentiles), all from the `ppf`. The mode is now placed on the lower bound when alpha ≤ 1 < beta and on the upper bound when beta ≤ 1 < alpha, rather than being called undefined; it is `None` only for the flat (alpha = beta = 1) and bimodal (alpha, beta < 1) cases.
 * **Lognormal** and **DiscreteUniform** — `statistics()` raised `TypeError: only 0-dimensional arrays can be converted to Python scalars` on numpy 2, since both called `float()` on a one-element array. Normal and Triangular already used `.flat[0]`; the others now do too.
 * **UncertaintyBase** — the inherited `statistics()` returned `params["loc"]` as an array, so every distribution that did not override it (Undefined, NoUncertainty, Bernoulli, Weibull, Gamma, GeneralizedExtremeValue, StudentsT) reported an array `mean`.

--- a/src/stats_arrays/distributions/discrete_uniform.py
+++ b/src/stats_arrays/distributions/discrete_uniform.py
@@ -85,13 +85,21 @@ class DiscreteUniform(UncertaintyBase):
     @one_row_params_array
     def statistics(cls, params: ParamsArray) -> dict:
         params = cls.fix_nan_minimum(params)
-        mean = float(((params["maximum"] + params["minimum"]) / 2).flat[0])
+        minimum = float(params["minimum"].flat[0])
+        maximum = float(params["maximum"].flat[0])
+        # The support is {minimum, ..., maximum - 1}, i.e. scipy's `randint(low, high)`
+        # with `high` excluded. For the integers a..b inclusive, mean and median are
+        # both (a + b) / 2, see
+        # https://en.wikipedia.org/wiki/Discrete_uniform_distribution. With
+        # b = maximum - 1 that is (minimum + maximum - 1) / 2. For an even count the
+        # median is the midpoint of the two middle values, as `numpy.median` defines it.
+        centre = (minimum + maximum - 1) / 2
         return {
-            "mean": mean,
+            "mean": centre,
             "mode": None,
-            "median": int(round(mean)),
-            "lower": float(params["minimum"].flat[0]),
-            "upper": float(params["maximum"].flat[0]),
+            "median": centre,
+            "lower": minimum,
+            "upper": maximum,
         }
 
     @classmethod

--- a/tests/distributions/test_discrete_uniform.py
+++ b/tests/distributions/test_discrete_uniform.py
@@ -1,4 +1,6 @@
 import numpy as np
+import pytest
+from scipy import stats as scipy_stats
 
 from stats_arrays.distributions import DiscreteUniform
 
@@ -25,3 +27,52 @@ def test_random_variables(make_params_array):
     params["maximum"] = 10
     sample = DiscreteUniform.random_variables(params, 10000)
     assert np.unique(sample).tolist() == [5, 6, 7, 8, 9]
+
+
+@pytest.mark.parametrize(
+    "minimum, maximum",
+    [(5, 10), (5, 9), (0, 2), (-3, 4)],
+    ids=["odd count", "even count", "two values", "spans zero"],
+)
+def test_statistics_match_support(make_params_array, minimum, maximum):
+    """Mean and median of the integers minimum..maximum-1.
+
+    Support is [low, high) as in `scipy.stats.randint`, and the mean of the
+    integers a..b is (a + b) / 2, so here (minimum + maximum - 1) / 2:
+    https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.randint.html
+    https://en.wikipedia.org/wiki/Discrete_uniform_distribution
+    """
+    params = make_params_array(length=1)
+    params["minimum"] = minimum
+    params["maximum"] = maximum
+    stats = DiscreteUniform.statistics(params)
+    support = np.arange(minimum, maximum)
+    assert stats["mean"] == scipy_stats.randint(minimum, maximum).mean()
+    assert stats["mean"] == support.mean()
+    # Midpoint of the two middle values for an even count, as numpy defines it:
+    # https://numpy.org/doc/stable/reference/generated/numpy.median.html
+    # scipy's `randint.median()` is `ppf(0.5)` and picks the lower one instead.
+    assert stats["median"] == np.median(support)
+    assert stats["mode"] is None
+    assert stats["lower"] == minimum
+    assert stats["upper"] == maximum
+    assert all(isinstance(stats[k], float) for k in ("mean", "median", "lower", "upper"))
+
+
+def test_statistics_mean_matches_samples(make_params_array):
+    params = make_params_array(length=1)
+    params["minimum"] = 5
+    params["maximum"] = 10
+    stats = DiscreteUniform.statistics(params)
+    sample = DiscreteUniform.random_variables(params, 100000, np.random.RandomState(0))
+    assert stats["mean"] == 7.0
+    assert np.isclose(sample.mean(), stats["mean"], atol=0.02)
+    assert np.median(sample) == stats["median"]
+
+
+def test_statistics_nan_minimum_defaults_to_zero(make_params_array):
+    params = make_params_array(length=1)
+    params["maximum"] = 4
+    stats = DiscreteUniform.statistics(params)
+    assert stats["lower"] == 0.0
+    assert stats["mean"] == stats["median"] == 1.5


### PR DESCRIPTION
`DiscreteUniform` covers the integers from `minimum` up to but excluding `maximum`, as its docstring and sampler agree. `statistics()` ignored the exclusion, so its `mean` was `(minimum + maximum) / 2` and its `median` was that rounded to an integer.

```python
import stats_arrays as sa

params = sa.UncertaintyBase.from_dicts({"minimum": 5, "maximum": 10, "uncertainty_type": 7})
sa.DiscreteUniform.statistics(params)
```

Before, on #38:

```
{'mean': 7.5, 'mode': None, 'median': 8, 'lower': 5.0, 'upper': 10.0}
```

The values are 5, 6, 7, 8 and 9, so the mean and median are both 7.

After:

```
{'mean': 7.0, 'mode': None, 'median': 7.0, 'lower': 5.0, 'upper': 10.0}
```

## Why `(minimum + maximum - 1) / 2` is right

1. **The support excludes `maximum`.** The class docstring says so, and `random_variables` draws with `numpy.random.RandomState.randint(low, high)`, whose `high` is exclusive ([numpy docs](https://numpy.org/doc/stable/reference/random/generated/numpy.random.RandomState.randint.html)). `cdf` uses `scipy.stats.randint(low, high)`, also half-open ([scipy docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.randint.html)). The existing test `test_random_variables` confirms that 5 to 10 yields exactly `[5, 6, 7, 8, 9]`.

2. **Mean of the integers a..b inclusive is `(a + b) / 2`** ([Wikipedia, discrete uniform distribution](https://en.wikipedia.org/wiki/Discrete_uniform_distribution)). Here `b = maximum - 1`, giving `(minimum + maximum - 1) / 2`. The new test checks this against `scipy.stats.randint(minimum, maximum).mean()` for four cases, and against the mean of 100,000 draws.

3. **The median is the same value.** For an odd count it is the middle integer. For an even count any value between the two middle integers is a median; the midpoint is the usual convention and is what `numpy.median` returns ([numpy docs](https://numpy.org/doc/stable/reference/generated/numpy.median.html)). The test checks against `numpy.median` of the support.

   scipy's `randint(...).median()` is `ppf(0.5)`, which returns the *lower* of the two middle values for an even count, e.g. 6 rather than 6.5 for 5 to 9. Both satisfy the definition. The midpoint is chosen because it agrees with `numpy.median` of any sample and is the value the mean also takes, and the test documents that scipy differs.

## Verification

```python
import numpy as np
from scipy import stats

print(stats.randint(5, 10).mean())            # 7.0
print(np.median(np.arange(5, 10)))            # 7.0
print(np.median(np.arange(5, 9)))             # 6.5  (even count)
print(stats.randint(5, 9).median())           # 6.0  (scipy's ppf(0.5) convention)
```

## Left alone

`lower` and `upper` still report `minimum` and `maximum`, the latter being outside the support. That is consistent with how `ppf` treats the bounds here and is not changed.

250 tests pass.