### PR TITLE
ci: run the test workflow on every push to a PR

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -9,22 +9,17 @@ name: Python 🐍 CI/CD tests
 on:
   push:
     branches: [main, develop]
-    paths-ignore: # prevents workflow execution when only these types of files are modified
-      - "**.md" # wildcards prevent file in any repo dir from trigering workflow
-      - "**.bib"
-      - "**.ya?ml" # captures both .yml and .yaml
-      - "LICENSE"
-      - ".gitignore"
   pull_request:
     branches: [main, develop]
-    types: [opened, reopened, synchronize]
-    paths-ignore:
-      - "**.md"
-      - "**.bib"
-      - "**.ya?ml"
-      - "LICENSE"
-      - ".gitignore"
+    # `ready_for_review` is not in the default set, so a draft marked ready
+    # would otherwise keep the checks from its last draft push.
+    types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch: # also allow manual trigger, for testing purposes
+
+# A new push to the same branch or PR supersedes the run in progress.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
The test workflow had a `paths-ignore` list on both its `push` and `pull_request` triggers: Markdown, YAML, `.bib`, `LICENSE` and `.gitignore`. GitHub evaluates that filter against the PR's full diff, so any PR whose whole change fell inside the list got no run at all. That covers a changelog-only PR, and it covers every change to the workflow file itself, which therefore shipped untested. See [the docs on `paths-ignore`](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore), in particular the note that pull requests are compared as a three-dot diff against the base.

This PR is itself the demonstration: it changes only a YAML file, and under the old filter it would show no checks. GitHub runs the workflow file from the PR head, so the checks below come from the new triggers.

## Changes

- **Drop `paths-ignore`** on both triggers. Each job takes about a minute, so the saving was small and the cost was a PR with no signal.
- **Add `ready_for_review`** to the `pull_request` types. It is not in the default set, so a draft marked ready kept the checks from its last draft push.
- **Add a `concurrency` group** keyed on the PR number, or the ref for pushes to `main`, with `cancel-in-progress`. A newer push to the same PR cancels the run it supersedes, which matters with an 18-job matrix.

## Not changed

`push` still runs only on `main` and `develop`. A branch without a PR gets no run, which seems intended. The publish workflow is untouched.