### PR TITLE
Release 3.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # stats_arrays Changelog
 
-# Unreleased
+# 3.0 (2026-09-02)
 
 ### Breaking changes
 
@@ -28,11 +28,8 @@
 * `validate()` error messages now include the specific row indices that failed (e.g. `Failing rows: [1, 3]`), making it much easier to diagnose problems in large parameter arrays.
 * Added `notebooks/stats_arrays_demo.ipynb`, a runnable example notebook covering params array construction, all RNG classes, PDF/CDF/PPF inspection, and a worked Monte Carlo propagation example.
 
-* `statistics()` no longer returns placeholder strings. **Beta** returned `"Not Implemented"` for `median`, `lower` and `upper`, and `"Undefined"` for `mode` when alpha or beta was at most 1; **DiscreteUniform** returned `"Undefined"` for `mode`. Undefined values are now `None`, as the base class has always documented.
-
 ### Bug fixes
 
-* **Beta** and **BetaPERT** — `statistics()` now reports `median`, `lower` and `upper` (the 2.5th and 97.5th percentiles), all from the `ppf`. The mode is now placed on the lower bound when alpha ≤ 1 < beta and on the upper bound when beta ≤ 1 < alpha, rather than being called undefined; it is `None` only for the flat (alpha = beta = 1) and bimodal (alpha, beta < 1) cases.
 * **Lognormal** — `pdf()` default x-axis was computed using μ instead of exp(μ), producing a wildly incorrect range.
 * **Bernoulli** — `cdf()` and `ppf()` were logically inverted: `P(X=0)` and `P(X=1)` were swapped.
 * **DiscreteUniform** — `cdf()` called `scipy.stats.randint` with `loc`/`scale` keyword arguments instead of the required positional `low`/`high` shape parameters, returning wrong probabilities.

--- a/src/stats_arrays/__init__.py
+++ b/src/stats_arrays/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.0"
+__version__ = "3.0"
 
 __all__ = (
     "BernoulliUncertainty",


### PR DESCRIPTION
## Release 3.0

Bumps version to `3.0` and dates the `CHANGES.md` section. Major bump because `statistics()` changes its return types.

### Breaking changes

- **`statistics()` returns Python floats throughout.** Several distributions returned single-element numpy arrays, so `result["mean"] == x` gave `array([True])` rather than a bool. The base class always documented floats. (PR #38)
- **`statistics()` no longer returns placeholder strings.** Beta returned `"Not Implemented"` and `"Undefined"`, DiscreteUniform returned `"Undefined"`. Undefined values are now `None`. (PR #38)

### Bug fixes

- Lognormal and DiscreteUniform `statistics()` raised `TypeError` on numpy 2 from `float()` on a one-element array (PR #38)
- Inherited `statistics()` returned an array `mean` for Undefined, NoUncertainty, Bernoulli, Weibull, Gamma, GeneralizedExtremeValue and StudentsT (PR #38)
- Uniform `statistics()` returned all five values as arrays (PR #38)
- Beta and BetaPERT `statistics()` now report `median`, `lower` and `upper` from the `ppf`, and place the mode on a bound when only one of alpha, beta exceeds 1 (PR #38)
- DiscreteUniform `statistics()` mean and median were off by one half, since the support excludes `maximum` (PR #39)

### Infrastructure

- CI runs on every push to a PR; `paths-ignore` had skipped docs-only and workflow-only changes (PR #40)

### Changelog repair

PR #38 inserted its two Beta entries into the 2.0 section of `CHANGES.md` as well as into Unreleased. This PR removes them from 2.0, which now matches the file as tagged at 2.0.