### PR TITLE
Ship type information (PEP 561)

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -22,6 +22,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          # Not the 3.9 floor: current mypy releases require 3.10+.
+          python-version: "3.12"
+
+      - name: Install package and mypy
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install . mypy
+
+      - name: Type check with mypy
+        run: |
+          mypy
+
   build:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,6 +61,16 @@ repos:
   # You can add flake8 plugins via `additional_dependencies`:
   #  additional_dependencies: [flake8-bugbear]
 
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v2.3.1
+  hooks:
+    - id: mypy
+      # `numpy` ships its own stubs and they are needed to check this package.
+      additional_dependencies: [numpy]
+      # Check the whole package via the `files` setting in pyproject.toml rather
+      # than only the staged files, which would hide cross-module breakage.
+      pass_filenames: false
+
 - repo: local
   hooks:
     - id: pylint

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,24 @@
 # stats_arrays Changelog
 
+# Unreleased
+
+### New features
+
+* `stats_arrays` is now a **typed library** (PEP 561). The package ships a `py.typed` marker, so type checkers use the inline annotations in downstream code instead of treating every import as `Any`. The whole package passes `mypy` with `disallow_untyped_defs` and `check_untyped_defs`, and that check runs in CI and as a pre-commit hook.
+* Two public type aliases are now exported for annotating your own code:
+  * `ParamsArray` — a :ref:`params-array`.
+  * `StatisticsResult` — a `TypedDict` for the return value of `statistics()`, with keys `mean`, `mode`, `median`, `lower` and `upper`, each `Optional[float]`. Misspelled keys are now a type error at check time.
+
+### Breaking changes
+
+* `UncertaintyBase.id` and `UncertaintyBase.description` are now declared but unset on the abstract base class, rather than defaulting to `None`. Every concrete distribution sets both, so `NormalUncertainty.id` is unchanged; only reading `id`/`description` directly off `UncertaintyBase` is affected, and that now raises `AttributeError` instead of returning `None`. This lets `id` be typed as `int` rather than `Optional[int]`, and makes the `hasattr(distribution, "id")` guard in `uncertainty_choices.add()` meaningful.
+
+### Bug fixes
+
+* **UncertaintyChoices.add()** — the guard rejecting distributions without an integer `id` could never fire: `hasattr(distribution, "id")` was always true because the base class supplied `None`, and the two conditions were combined with `and` rather than `or`. It now checks `isinstance(getattr(distribution, "id", None), int)`.
+* **UncertaintyChoices** — the duplicate-id `ValueError` and the already-present `UserWarning` both formatted a class object with `{:d}`, which would itself raise `TypeError` instead of reporting the actual problem.
+* **UncertaintyBase.pdf()** — the base class declared a return type of `NDArray`, but every implementation returns a `(xs, ys)` tuple, as its own docstring describes. The annotation now says `Tuple[NDArray, NDArray]`.
+
 # 3.0 (2026-09-02)
 
 ### Breaking changes

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,5 @@ include *.md
 include *.txt
 include LICENSE
 recursive-include stats_arrays *.py
+include src/stats_arrays/py.typed
 recursive-include docs *.rst

--- a/README.md
+++ b/README.md
@@ -43,6 +43,28 @@ array([ 2.74414022,  3.54748507])
 
 ```
 
+# Type checking
+
+`stats_arrays` is a typed library. It ships a `py.typed` marker (PEP 561), so `mypy`,
+`pyright` and friends will use its inline annotations rather than treating the package
+as untyped. Two aliases are exported for annotating your own code:
+
+```python
+from typing import Optional
+
+from stats_arrays import NormalUncertainty, ParamsArray, StatisticsResult
+
+params: ParamsArray = NormalUncertainty.from_dicts({"loc": 2.0, "scale": 0.5})
+stats: StatisticsResult = NormalUncertainty.statistics(params)
+mean: Optional[float] = stats["mean"]
+```
+
+`StatisticsResult` is a `TypedDict` with the keys `mean`, `mode`, `median`, `lower` and
+`upper`; a statistic that is undefined for a given distribution is `None`, never absent.
+
+Note that the field layout of a params array is not expressible in NumPy's typing system,
+so `ParamsArray` documents intent and field access (`params["loc"]`) stays untyped.
+
 # More
 
 * Source code: https://github.com/brightway-lca/stats_arrays

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ testing = [
 ]
 dev = [
     "build",
+    "mypy",
     "pre-commit",
     "pylint",
     "pytest",
@@ -112,3 +113,28 @@ include_trailing_comma = true
 force_grid_wrap = 0
 use_parentheses = true
 ensure_newline_before_comments = true
+
+[tool.mypy]
+files = ["src/stats_arrays"]
+# `python_version` is deliberately unset. Current mypy releases refuse to target
+# anything below 3.10, and pinning it also breaks parsing of NumPy's own stubs.
+# Checks therefore run against the interpreter in use; the annotations here stay
+# 3.9-compatible (`typing.Optional`/`Tuple` rather than `X | None`).
+# `stats_arrays` ships a `py.typed` marker, so every public symbol needs an
+# annotation that downstream type checkers can rely on.
+disallow_untyped_defs = true
+check_untyped_defs = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_unused_configs = true
+# Full `--strict` is not workable against NumPy's stubs: array operations are
+# pervasively `Any`, so `warn_return_any` would produce hundreds of findings
+# that say nothing about this codebase.
+warn_return_any = false
+
+[[tool.mypy.overrides]]
+# SciPy ships no type information, and `scipy-stubs` requires Python >= 3.11
+# while this package supports 3.9+.
+module = ["scipy.*"]
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
     "Natural Language :: English",
     "Operating System :: OS Independent",
-    "Topic :: Scientific/Engineering"
+    "Topic :: Scientific/Engineering",
+    "Typing :: Typed"
 ]
 requires-python = ">=3.9"
 dependencies = [
@@ -67,6 +68,10 @@ packages = [
     "stats_arrays",
     "stats_arrays.distributions",
 ]
+
+[tool.setuptools.package-data]
+# PEP 561 marker: tells type checkers the inline annotations are to be trusted.
+stats_arrays = ["py.typed"]
 
 [tool.setuptools.dynamic]
 version = {attr = "stats_arrays.__version__"}

--- a/src/stats_arrays/__init__.py
+++ b/src/stats_arrays/__init__.py
@@ -18,7 +18,9 @@ __all__ = (
     "MultipleRowParamsArrayError",
     "NormalUncertainty",
     "NoUncertainty",
+    "ParamsArray",
     "RandomNumberGenerator",
+    "StatisticsResult",
     "StatsArraysError",
     "StudentsTUncertainty",
     "TriangularUncertainty",
@@ -67,3 +69,4 @@ from stats_arrays.random import (
 )
 from stats_arrays.uncertainty_choices import uncertainty_choices
 from stats_arrays.uncertainty_types import UncertaintyType
+from stats_arrays.utils import ParamsArray, StatisticsResult

--- a/src/stats_arrays/dataset_statistics.py
+++ b/src/stats_arrays/dataset_statistics.py
@@ -1,3 +1,6 @@
+from typing import Any
+
+import numpy as np
 import numpy.typing as npt
 from numpy import array
 
@@ -8,23 +11,27 @@ from numpy import array
 # http://pygsl.sourceforge.net/reference/pygsl/node36.html
 
 
-def weighted_mean(values: npt.NDArray, weights: npt.NDArray) -> npt.NDArray:
+def weighted_mean(values: npt.NDArray, weights: npt.NDArray) -> np.floating[Any]:
     assert values.shape == weights.shape
     return (values * weights).sum() / weights.sum()
 
 
-def weighted_sample_variance(values: npt.NDArray, weights: npt.NDArray) -> npt.NDArray:
+def weighted_sample_variance(
+    values: npt.NDArray, weights: npt.NDArray
+) -> np.floating[Any]:
     assert values.shape == weights.shape
     return (
         (weights * values**2).sum() * weights.sum() - ((weights * values).sum()) ** 2
     ) / ((weights.sum()) ** 2 - (weights**2).sum())
 
 
-def weighted_sample_stddev(values: npt.NDArray, weights: npt.NDArray) -> npt.NDArray:
+def weighted_sample_stddev(
+    values: npt.NDArray, weights: npt.NDArray
+) -> np.floating[Any]:
     return weighted_sample_variance(values, weights) ** 0.5
 
 
-def test():
+def test() -> None:
     a = array((1, 2, 3, 4))
     print(a**2)
     b = array((0.5, 0.5, 1, 1))

--- a/src/stats_arrays/distributions/base.py
+++ b/src/stats_arrays/distributions/base.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import Any, ClassVar, Dict, List, Optional, Tuple
 
 import numpy as np
 import numpy.typing as npt
@@ -11,6 +11,7 @@ from stats_arrays.errors import (
 )
 from stats_arrays.utils import (
     ParamsArray,
+    StatisticsResult,
     construct_params_array,
     one_row_params_array,
     rescale_to_unitary_interval,
@@ -33,9 +34,14 @@ class UncertaintyBase:
 
     """
 
-    id = None
-    default_number_points_in_pdf = 200
-    standard_deviations_in_default_range = 2.2
+    #: Integer distribution id, unique across ``uncertainty_choices``. Declared but
+    #: deliberately unset here: ``UncertaintyBase`` is abstract, and every concrete
+    #: subclass must supply its own id. See :class:`stats_arrays.UncertaintyType`.
+    id: ClassVar[int]
+    #: Human-readable name of the distribution. Set by each concrete subclass.
+    description: ClassVar[str]
+    default_number_points_in_pdf: ClassVar[int] = 200
+    standard_deviations_in_default_range: ClassVar[float] = 2.2
 
     @staticmethod
     def _fmt_bad_rows(mask: npt.NDArray) -> str:
@@ -45,7 +51,7 @@ class UncertaintyBase:
 
     # Conversion utilities ###
     @classmethod
-    def from_tuples(cls, *data: tuple) -> ParamsArray:
+    def from_tuples(cls, *data: Tuple[Any, ...]) -> ParamsArray:
         """
         Construct a :ref:`hpa` from parameter tuples.
 
@@ -95,7 +101,7 @@ class UncertaintyBase:
         return params
 
     @classmethod
-    def from_dicts(cls, *dicts: dict) -> ParamsArray:
+    def from_dicts(cls, *dicts: Dict[str, Any]) -> ParamsArray:
         """
         Construct a :ref:`hpa` from parameter dictionaries.
 
@@ -124,7 +130,7 @@ class UncertaintyBase:
             A :ref:`hpa`
 
         """
-        LABELS = [
+        LABELS: List[Tuple[str, Any]] = [
             ("loc", np.nan),
             ("scale", np.nan),
             ("shape", np.nan),
@@ -162,9 +168,7 @@ class UncertaintyBase:
         # Minimum <= Maximum
         bad = params["minimum"] >= params["maximum"]
         if bad.any():
-            raise ImproperBoundsError(
-                f"minimum >= maximum. {cls._fmt_bad_rows(bad)}"
-            )
+            raise ImproperBoundsError(f"minimum >= maximum. {cls._fmt_bad_rows(bad)}")
 
     @classmethod
     def check_2d_inputs(cls, params: ParamsArray, vector: npt.NDArray) -> npt.NDArray:
@@ -208,7 +212,7 @@ class UncertaintyBase:
             )
 
     @staticmethod
-    def _check_seeded_random(seeded_random) -> None:
+    def _check_seeded_random(seeded_random: Any) -> None:
         """Raise TypeError if seeded_random is not None or a numpy RandomState.
 
         Integers are rejected here because the public API for seeded sampling is
@@ -330,7 +334,7 @@ class UncertaintyBase:
     # Used for graphing ###
     @classmethod
     @one_row_params_array
-    def statistics(cls, params: ParamsArray) -> dict:
+    def statistics(cls, params: ParamsArray) -> StatisticsResult:
         """Build a dictionary of mean, mode, median, and 95% confidence interval upper and lower values.
 
         .. rubric:: Inputs
@@ -351,7 +355,9 @@ class UncertaintyBase:
 
     @classmethod
     @one_row_params_array
-    def pdf(cls, params: ParamsArray, xs: Optional[npt.NDArray] = None) -> npt.NDArray:
+    def pdf(
+        cls, params: ParamsArray, xs: Optional[npt.NDArray] = None
+    ) -> Tuple[npt.NDArray, npt.NDArray]:
         """Provide a standard interface to calculate the probability distribution function of a uncertainty distribution. Default is `cls.default_number_points_in_pdf` points between min to max range if bounds are present, or `cls.standard_deviations_in_default_range` standard distributions.
 
         .. rubric:: Inputs
@@ -406,6 +412,8 @@ class BoundedUncertaintyBase(UncertaintyBase):
 
     @classmethod
     @one_row_params_array
-    def check_bounds_reasonableness(cls, params: ParamsArray) -> None:
+    def check_bounds_reasonableness(
+        cls, params: ParamsArray, threshold: float = 0.1
+    ) -> None:
         """Always true because the bounds do not exclude any of the distribution."""
         return

--- a/src/stats_arrays/distributions/beta.py
+++ b/src/stats_arrays/distributions/beta.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Tuple
 
 import numpy as np
 import numpy.typing as npt
@@ -8,6 +8,7 @@ from stats_arrays.distributions.base import UncertaintyBase
 from stats_arrays.errors import ImproperBoundsError, InvalidParamsError
 from stats_arrays.utils import (
     ParamsArray,
+    StatisticsResult,
     one_row_params_array,
     rescale_vector_to_params,
 )
@@ -116,7 +117,7 @@ class BetaUncertainty(UncertaintyBase):
 
     @classmethod
     @one_row_params_array
-    def statistics(cls, params: ParamsArray) -> dict:
+    def statistics(cls, params: ParamsArray) -> StatisticsResult:
         alpha, beta = float(params["loc"].flat[0]), float(params["shape"].flat[0])
         minimum = float(cls._safe_loc(params).flat[0])
         scale = float(cls._safe_scale(params).flat[0])
@@ -144,10 +145,9 @@ class BetaUncertainty(UncertaintyBase):
     @one_row_params_array
     def pdf(
         cls, params: ParamsArray, xs: Optional[npt.NDArray] = None
-    ) -> tuple[npt.NDArray, npt.NDArray]:
-        loc, scale = cls._safe_loc(params), cls._safe_scale(params)
-        loc = float(loc[0][0])
-        scale = float(scale[0][0])
+    ) -> Tuple[npt.NDArray, npt.NDArray]:
+        loc = float(cls._safe_loc(params)[0][0])
+        scale = float(cls._safe_scale(params)[0][0])
 
         if xs is None:
             xs = np.linspace(loc, loc + scale, cls.default_number_points_in_pdf)

--- a/src/stats_arrays/distributions/beta_pert.py
+++ b/src/stats_arrays/distributions/beta_pert.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Tuple
 
 import numpy as np
 import numpy.typing as npt
@@ -6,7 +6,7 @@ from numpy import isnan, nan
 
 from stats_arrays.distributions.beta import BetaUncertainty
 from stats_arrays.errors import ImproperBoundsError, InvalidParamsError
-from stats_arrays.utils import one_row_params_array
+from stats_arrays.utils import ParamsArray, StatisticsResult, one_row_params_array
 
 
 class BetaPERTUncertainty(BetaUncertainty):
@@ -27,7 +27,7 @@ class BetaPERTUncertainty(BetaUncertainty):
     description = "Beta PERT uncertainty"
 
     @classmethod
-    def validate(cls, params: npt.NDArray) -> None:
+    def validate(cls, params: ParamsArray) -> None:
         bad = isnan(params["minimum"])
         if bad.any():
             raise InvalidParamsError(
@@ -63,7 +63,7 @@ class BetaPERTUncertainty(BetaUncertainty):
             )
 
     @classmethod
-    def _as_beta(cls, params: npt.NDArray, default_lambda: float = 4.0) -> npt.NDArray:
+    def _as_beta(cls, params: ParamsArray, default_lambda: float = 4.0) -> ParamsArray:
         """Calculate α and β values for Beta distribution from PERT A/B/C inputs."""
         beta = params.copy()
         # Use provided lambda values or default
@@ -84,7 +84,7 @@ class BetaPERTUncertainty(BetaUncertainty):
     @classmethod
     def random_variables(
         cls,
-        params: npt.NDArray,
+        params: ParamsArray,
         size: int,
         seeded_random: Optional[np.random.RandomState] = None,
         transform: bool = False,
@@ -99,7 +99,7 @@ class BetaPERTUncertainty(BetaUncertainty):
 
     @classmethod
     def cdf(
-        cls, params: npt.NDArray, vector: npt.NDArray, default_lambda: float = 4.0
+        cls, params: ParamsArray, vector: npt.NDArray, default_lambda: float = 4.0
     ) -> npt.NDArray:
         return BetaUncertainty.cdf(
             params=cls._as_beta(params=params, default_lambda=default_lambda),
@@ -108,7 +108,7 @@ class BetaPERTUncertainty(BetaUncertainty):
 
     @classmethod
     def ppf(
-        cls, params: npt.NDArray, percentages: npt.NDArray, default_lambda: float = 4.0
+        cls, params: ParamsArray, percentages: npt.NDArray, default_lambda: float = 4.0
     ) -> npt.NDArray:
         return BetaUncertainty.ppf(
             params=cls._as_beta(params=params, default_lambda=default_lambda),
@@ -117,7 +117,9 @@ class BetaPERTUncertainty(BetaUncertainty):
 
     @classmethod
     @one_row_params_array
-    def statistics(cls, params: npt.NDArray, default_lambda: float = 4.0) -> dict:
+    def statistics(
+        cls, params: ParamsArray, default_lambda: float = 4.0
+    ) -> StatisticsResult:
         return BetaUncertainty.statistics(
             params=cls._as_beta(params=params, default_lambda=default_lambda)
         )
@@ -126,10 +128,10 @@ class BetaPERTUncertainty(BetaUncertainty):
     @one_row_params_array
     def pdf(
         cls,
-        params: npt.NDArray,
+        params: ParamsArray,
         xs: Optional[npt.NDArray] = None,
         default_lambda: float = 4.0,
-    ) -> tuple[npt.NDArray, npt.NDArray]:
+    ) -> Tuple[npt.NDArray, npt.NDArray]:
         return BetaUncertainty.pdf(
             params=cls._as_beta(params=params, default_lambda=default_lambda), xs=xs
         )

--- a/src/stats_arrays/distributions/discrete_uniform.py
+++ b/src/stats_arrays/distributions/discrete_uniform.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Tuple
 
 import numpy as np
 import numpy.typing as npt
@@ -6,7 +6,7 @@ from scipy import stats
 
 from stats_arrays.distributions.base import UncertaintyBase
 from stats_arrays.errors import ImproperBoundsError, InvalidParamsError
-from stats_arrays.utils import ParamsArray, one_row_params_array
+from stats_arrays.utils import ParamsArray, StatisticsResult, one_row_params_array
 
 
 class DiscreteUniform(UncertaintyBase):
@@ -28,9 +28,7 @@ class DiscreteUniform(UncertaintyBase):
             )
         bad = params["minimum"] >= params["maximum"]
         if bad.any():
-            raise ImproperBoundsError(
-                f"minimum >= maximum. {cls._fmt_bad_rows(bad)}"
-            )
+            raise ImproperBoundsError(f"minimum >= maximum. {cls._fmt_bad_rows(bad)}")
 
     @classmethod
     def fix_nan_minimum(cls, params: ParamsArray) -> ParamsArray:
@@ -83,7 +81,7 @@ class DiscreteUniform(UncertaintyBase):
 
     @classmethod
     @one_row_params_array
-    def statistics(cls, params: ParamsArray) -> dict:
+    def statistics(cls, params: ParamsArray) -> StatisticsResult:
         params = cls.fix_nan_minimum(params)
         minimum = float(params["minimum"].flat[0])
         maximum = float(params["maximum"].flat[0])
@@ -106,7 +104,7 @@ class DiscreteUniform(UncertaintyBase):
     @one_row_params_array
     def pdf(
         cls, params: ParamsArray, xs: Optional[npt.NDArray] = None
-    ) -> tuple[npt.NDArray, npt.NDArray]:
+    ) -> Tuple[npt.NDArray, npt.NDArray]:
         params = cls.fix_nan_minimum(params)
         if xs is None:
             xs = np.array([params["minimum"], params["maximum"]])

--- a/src/stats_arrays/distributions/extreme.py
+++ b/src/stats_arrays/distributions/extreme.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Optional
 
 import numpy as np
 import numpy.typing as npt
@@ -46,7 +46,7 @@ class GeneralizedExtremeValueUncertainty(UncertaintyBase):
         params: ParamsArray,
         size: int,
         seeded_random: Optional[np.random.RandomState] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> npt.NDArray:
         if seeded_random is None:
             seeded_random = np.random.RandomState()

--- a/src/stats_arrays/distributions/gamma.py
+++ b/src/stats_arrays/distributions/gamma.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Optional
 
 import numpy as np
 import numpy.typing as npt
@@ -43,7 +43,7 @@ class GammaUncertainty(UncertaintyBase):
         params: ParamsArray,
         size: int,
         seeded_random: Optional[np.random.RandomState] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> npt.NDArray:
         if seeded_random is None:
             seeded_random = np.random.RandomState()

--- a/src/stats_arrays/distributions/geometric.py
+++ b/src/stats_arrays/distributions/geometric.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Tuple
 
 import numpy as np
 import numpy.typing as npt
@@ -6,7 +6,7 @@ from scipy import stats
 
 from stats_arrays.distributions.base import BoundedUncertaintyBase
 from stats_arrays.errors import ImproperBoundsError
-from stats_arrays.utils import ParamsArray, one_row_params_array
+from stats_arrays.utils import ParamsArray, StatisticsResult, one_row_params_array
 
 
 class UniformUncertainty(BoundedUncertaintyBase):
@@ -50,7 +50,7 @@ class UniformUncertainty(BoundedUncertaintyBase):
 
     @classmethod
     @one_row_params_array
-    def statistics(cls, params: ParamsArray) -> dict:
+    def statistics(cls, params: ParamsArray) -> StatisticsResult:
         mean = float(((params["maximum"] + params["minimum"]) / 2).flat[0])
         return {
             "mean": mean,
@@ -64,7 +64,7 @@ class UniformUncertainty(BoundedUncertaintyBase):
     @one_row_params_array
     def pdf(
         cls, params: ParamsArray, xs: Optional[npt.NDArray] = None
-    ) -> tuple[npt.NDArray, npt.NDArray]:
+    ) -> Tuple[npt.NDArray, npt.NDArray]:
         if xs is None:
             xs_array = np.array([params["minimum"], params["maximum"]]).reshape(
                 2,
@@ -135,7 +135,7 @@ class TriangularUncertainty(BoundedUncertaintyBase):
 
     @classmethod
     @one_row_params_array
-    def statistics(cls, params: ParamsArray) -> dict:
+    def statistics(cls, params: ParamsArray) -> StatisticsResult:
         mode = float(params["loc"].flat[0])
         mean = float(((params["minimum"] + params["maximum"] + mode) / 3).flat[0])
         lower, median, upper = cls.ppf(
@@ -153,7 +153,7 @@ class TriangularUncertainty(BoundedUncertaintyBase):
     @one_row_params_array
     def pdf(
         cls, params: ParamsArray, xs: Optional[npt.NDArray] = None
-    ) -> tuple[npt.NDArray, npt.NDArray]:
+    ) -> Tuple[npt.NDArray, npt.NDArray]:
         adjusted_means, scale = cls.rescale_to_unitary_interval(params)
         if xs is None:
             xs = np.linspace(

--- a/src/stats_arrays/distributions/lognormal.py
+++ b/src/stats_arrays/distributions/lognormal.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Tuple
 
 import numpy as np
 import numpy.typing as npt
@@ -6,7 +6,7 @@ from scipy import stats
 
 from stats_arrays.distributions.base import UncertaintyBase
 from stats_arrays.errors import InvalidParamsError
-from stats_arrays.utils import ParamsArray, one_row_params_array
+from stats_arrays.utils import ParamsArray, StatisticsResult, one_row_params_array
 
 
 class LognormalUncertainty(UncertaintyBase):
@@ -86,7 +86,7 @@ class LognormalUncertainty(UncertaintyBase):
 
     @classmethod
     @one_row_params_array
-    def statistics(cls, params: ParamsArray) -> dict:
+    def statistics(cls, params: ParamsArray) -> StatisticsResult:
         negative = -1 if bool(params["negative"].flat[0]) else 1
         mu = float(params["loc"].flat[0])
         sigma = float(params["scale"].flat[0])
@@ -110,7 +110,7 @@ class LognormalUncertainty(UncertaintyBase):
     @one_row_params_array
     def pdf(
         cls, params: ParamsArray, xs: Optional[npt.NDArray] = None
-    ) -> tuple[npt.NDArray, npt.NDArray]:
+    ) -> Tuple[npt.NDArray, npt.NDArray]:
         """Generate probability distribution function for lognormal distribution."""
         n = params["negative"]
         if xs is None:

--- a/src/stats_arrays/distributions/normal.py
+++ b/src/stats_arrays/distributions/normal.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Tuple
 
 import numpy as np
 import numpy.typing as npt
@@ -6,7 +6,7 @@ from scipy import stats
 
 from stats_arrays.distributions.base import UncertaintyBase
 from stats_arrays.errors import InvalidParamsError
-from stats_arrays.utils import ParamsArray, one_row_params_array
+from stats_arrays.utils import ParamsArray, StatisticsResult, one_row_params_array
 
 
 class NormalUncertainty(UncertaintyBase):
@@ -63,7 +63,7 @@ class NormalUncertainty(UncertaintyBase):
 
     @classmethod
     @one_row_params_array
-    def statistics(cls, params: ParamsArray) -> dict:
+    def statistics(cls, params: ParamsArray) -> StatisticsResult:
         return {
             "mean": float(params["loc"].flat[0]),
             "mode": float(params["loc"].flat[0]),
@@ -76,7 +76,7 @@ class NormalUncertainty(UncertaintyBase):
     @one_row_params_array
     def pdf(
         cls, params: ParamsArray, xs: Optional[npt.NDArray] = None
-    ) -> tuple[npt.NDArray, npt.NDArray]:
+    ) -> Tuple[npt.NDArray, npt.NDArray]:
         if xs is None:
             if np.isnan(params["minimum"]):
                 lower = (

--- a/src/stats_arrays/distributions/student.py
+++ b/src/stats_arrays/distributions/student.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Optional
 
 import numpy as np
 import numpy.typing as npt
@@ -47,7 +47,7 @@ class StudentsTUncertainty(UncertaintyBase):
         params: ParamsArray,
         size: int,
         seeded_random: Optional[np.random.RandomState] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> npt.NDArray:
         if seeded_random is None:
             seeded_random = np.random.RandomState()

--- a/src/stats_arrays/random.py
+++ b/src/stats_arrays/random.py
@@ -1,5 +1,4 @@
-from collections.abc import Iterable
-from typing import Iterator, Optional, Type
+from typing import Any, Dict, Iterable, Iterator, Optional, Type
 
 import numpy as np
 import numpy.typing as npt
@@ -10,7 +9,7 @@ from stats_arrays.uncertainty_choices import uncertainty_choices
 from stats_arrays.utils import ParamsArray
 
 
-class RandomNumberGenerator(Iterable):
+class RandomNumberGenerator(Iterable[npt.NDArray]):
     def __init__(
         self,
         uncertainty_type: Type[UncertaintyBase],
@@ -18,8 +17,8 @@ class RandomNumberGenerator(Iterable):
         size: int = 1,
         maximum_iterations: int = 100,
         seed: Optional[int] = None,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         """
         Create a random number generator from a :ref:`params-array` and an uncertainty distribution.
 
@@ -98,7 +97,7 @@ class RandomNumberGenerator(Iterable):
         self,
         uncertainty_type: Optional[Type[UncertaintyBase]] = None,
         params: Optional[ParamsArray] = None,
-        size=None,
+        size: Optional[int] = None,
     ) -> npt.NDArray:
         if not uncertainty_type:
             uncertainty_type = self.uncertainty_type
@@ -120,7 +119,7 @@ class RandomNumberGenerator(Iterable):
         return self
 
 
-class MCRandomNumberGenerator(Iterable):
+class MCRandomNumberGenerator(Iterable[npt.NDArray]):
     """
     A Monte Carlo random number generator that operates on a :ref:`hpa`.
 
@@ -156,8 +155,8 @@ class MCRandomNumberGenerator(Iterable):
         params: ParamsArray,
         maximum_iterations: int = 50,
         seed: Optional[int] = None,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         self.params = params.copy()
         self.length = self.params.shape[0]
         self.maximum_iterations = maximum_iterations
@@ -169,7 +168,7 @@ class MCRandomNumberGenerator(Iterable):
         self.params = self.params[self.ordering]
         self.positions = self.get_positions()
 
-    def get_positions(self) -> dict:
+    def get_positions(self) -> Dict[Type[UncertaintyBase], int]:
         """Construct dictionary of where each distribution starts and stops in the sorted parameter array"""
         return dict(
             [
@@ -251,8 +250,8 @@ class LatinHypercubeRNG(MCRandomNumberGenerator):
         params: ParamsArray,
         seed: Optional[int] = None,
         samples: int = 10,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         self.params = params
         self.length = self.params.shape[0]
         self.row_index = np.arange(self.length)

--- a/src/stats_arrays/uncertainty_choices.py
+++ b/src/stats_arrays/uncertainty_choices.py
@@ -1,11 +1,11 @@
 import warnings
 from collections.abc import Iterable as IterableABC
-from typing import Iterator, Type, TypeVar
+from typing import Dict, Iterator, List, Type
 
 from stats_arrays.distributions import (
     BernoulliUncertainty,
-    BetaUncertainty,
     BetaPERTUncertainty,
+    BetaUncertainty,
     DiscreteUniform,
     GammaUncertainty,
     GeneralizedExtremeValueUncertainty,
@@ -38,9 +38,6 @@ DISTRIBUTIONS = (
 )
 
 
-DistributionType = TypeVar("DistributionType", bound=UncertaintyBase, covariant=True)
-
-
 class UncertaintyChoices(IterableABC[Type[UncertaintyBase]]):
     """A container for uncertainty distributions, keyed by integer ID.
 
@@ -51,9 +48,14 @@ class UncertaintyChoices(IterableABC[Type[UncertaintyBase]]):
         uncertainty_choices[3]                        # same thing
     """
 
-    def __init__(self):
+    #: Distributions in this container, sorted by ``id``.
+    choices: List[Type[UncertaintyBase]]
+    #: Lookup from integer ``id`` to distribution class.
+    id_dict: Dict[int, Type[UncertaintyBase]]
+
+    def __init__(self) -> None:
         # Sorted by id
-        self.choices: list = sorted(DISTRIBUTIONS, key=lambda x: x.id)
+        self.choices = sorted(DISTRIBUTIONS, key=lambda x: x.id)
         self.check_id_uniqueness()
 
     def check_id_uniqueness(self) -> None:

--- a/src/stats_arrays/uncertainty_choices.py
+++ b/src/stats_arrays/uncertainty_choices.py
@@ -61,8 +61,8 @@ class UncertaintyChoices(IterableABC[Type[UncertaintyBase]]):
         for dist in self.choices:
             if dist.id in self.id_dict:
                 raise ValueError(
-                    "Uncertainty id {:d} is already in use by {:d}".format(
-                        dist.id, self.id_dict[dist.id]
+                    "Uncertainty id {} is already in use by {}".format(
+                        dist.id, self.id_dict[dist.id].__name__
                     )
                 )
             self.id_dict[dist.id] = dist
@@ -80,13 +80,13 @@ class UncertaintyChoices(IterableABC[Type[UncertaintyBase]]):
         return choice in self.choices
 
     def add(self, distribution: Type[UncertaintyBase]) -> None:
-        if not hasattr(distribution, "id") and isinstance(distribution.id, int):
+        if not isinstance(getattr(distribution, "id", None), int):
             raise ValueError(
                 "Uncertainty distributions must have integer `id` attribute."
             )
         if distribution.id in self.id_dict:
             warnings.warn(
-                "ERROR: This distribution (id {:d}) is already present!".format(
+                "ERROR: This distribution (id {}) is already present!".format(
                     distribution.id
                 )
             )

--- a/src/stats_arrays/utils.py
+++ b/src/stats_arrays/utils.py
@@ -1,12 +1,22 @@
 from functools import wraps
-from typing import Any, Callable, List, Tuple, TypeVar, overload
+from typing import (
+    Any,
+    Callable,
+    List,
+    Optional,
+    Tuple,
+    TypedDict,
+    TypeVar,
+    cast,
+    overload,
+)
 
 import numpy as np
 import numpy.typing as npt
 
 from stats_arrays.errors import MultipleRowParamsArrayError
 
-BASE_DTYPE_FIELDS: List[tuple] = [
+BASE_DTYPE_FIELDS: List[Tuple[str, type]] = [
     ("loc", np.float64),
     ("scale", np.float64),
     ("shape", np.float64),
@@ -14,43 +24,59 @@ BASE_DTYPE_FIELDS: List[tuple] = [
     ("maximum", np.float64),
     ("negative", bool),
 ]
-BASE_DTYPE: npt.DTypeLike = np.dtype(BASE_DTYPE_FIELDS)
+BASE_DTYPE: np.dtype = np.dtype(BASE_DTYPE_FIELDS)
 
-# Numpy typing isn't great, use this basic approach for now.
-# Also consider nptyping: https://stackoverflow.com/questions/71109838/numpy-typing-with-specific-shape-and-datatype
-# TODO: Decide if we need separate types for when "uncertainty_type is included"
-# @overload
-# def construct_params_array(length: int = 1, include_type: bool = False) -> BaseParamsArray:
-#     ...
-# @overload
-# def construct_params_array(length: int = 1, include_type: bool = True) -> ExtendedParamsArray:
-#     ...
-# More specific types for different parameter array structures
-# BaseParamsArray = npt.NDArray[BASE_DTYPE_T]  # Without uncertainty_type
-# ExtendedParamsArray = npt.NDArray[BASE_DTYPE_T]  # With uncertainty_type
-BASE_DTYPE_T = TypeVar("BASE_DTYPE_T", bound=np.generic)
-ParamsArray = npt.NDArray[BASE_DTYPE_T]
+ParamsArray = npt.NDArray[np.void]
+"""A :ref:`params-array`: a structured NumPy array whose fields are ``loc``, ``scale``,
+``shape``, ``minimum``, ``maximum``, ``negative``, and — for a :ref:`hpa` — the
+``uncertainty_type`` distribution id.
+
+Structured arrays all share the ``numpy.void`` scalar type, so this alias documents
+intent rather than pinning an exact dtype; the field layout is not expressible in the
+NumPy typing system today. Field access (``params["loc"]``) is therefore untyped.
+"""
+
+
+class StatisticsResult(TypedDict):
+    """Summary statistics returned by :meth:`UncertaintyBase.statistics`.
+
+    Every key is always present. A statistic that is undefined for a given
+    distribution and parameter set is ``None`` rather than omitted.
+    """
+
+    mean: Optional[float]
+    mode: Optional[float]
+    median: Optional[float]
+    lower: Optional[float]
+    upper: Optional[float]
+
+
+AnyCallable = TypeVar("AnyCallable", bound=Callable[..., Any])
 
 
 @overload
-def flatten_numpy_array(obj: npt.NDArray) -> npt.NDArray:
-    ...
+def flatten_numpy_array(obj: npt.NDArray) -> npt.NDArray: ...
 
 
 @overload
+def flatten_numpy_array(obj: Any) -> Any: ...
+
+
 def flatten_numpy_array(obj: Any) -> Any:
-    ...
-
-
-def flatten_numpy_array(obj):
     if not isinstance(obj, np.ndarray):
         return obj
     return obj.ravel()
 
 
-def one_row_params_array(function: Callable) -> Callable:
+def one_row_params_array(function: AnyCallable) -> AnyCallable:
+    """Reshape ``params`` to a single row, and flatten any other array arguments.
+
+    Raises ``stats_arrays.MultipleRowParamsArrayError`` if ``params`` has more than one
+    row. The wrapped callable keeps the signature of ``function``.
+    """
+
     @wraps(function)
-    def wrapper(cls, params: ParamsArray, *args, **kwargs) -> Callable:
+    def wrapper(cls: Any, params: ParamsArray, *args: Any, **kwargs: Any) -> Any:
         if len(params.shape) == 1:
             params = params.reshape(params.shape[0], 1)
         else:
@@ -58,14 +84,17 @@ def one_row_params_array(function: Callable) -> Callable:
                 raise MultipleRowParamsArrayError
         # Flatten any additional inputs to one dimension
         # Needed for PDF optional xs input
-        args = [flatten_numpy_array(x) for x in args]
-        kwargs = {key: flatten_numpy_array(obj) for key, obj in kwargs.items()}
-        return function(cls, params, *args, **kwargs)
+        flattened_args = [flatten_numpy_array(x) for x in args]
+        flattened_kwargs = {
+            key: flatten_numpy_array(obj) for key, obj in kwargs.items()
+        }
+        return function(cls, params, *flattened_args, **flattened_kwargs)
 
-    return wrapper
+    return cast(AnyCallable, wrapper)
 
 
 def construct_params_array(length: int = 1, include_type: bool = False) -> ParamsArray:
+    dtype: np.dtype
     if include_type:
         dtype = np.dtype(BASE_DTYPE_FIELDS + [("uncertainty_type", np.uint8)])
     else:


### PR DESCRIPTION
The package is annotated, but there is no `py.typed` marker, so type checkers ignore the annotations and every import resolves to `Any`.

## Steps to reproduce

`python 3.12`, `stats_arrays 3.0`, `mypy 2.3.1`, on `main` at bfbaf5a.

```python
from stats_arrays import NormalUncertainty

params = NormalUncertainty.from_dicts({"loc": 2.0, "scale": 0.5})
stats = NormalUncertainty.statistics(params)
reveal_type(stats)
bad: str = stats["mean"]
typo = stats["maen"]
```

```
consumer.py:1: error: Skipping analyzing "stats_arrays": module is installed, but missing library stubs or py.typed marker  [import-untyped]
consumer.py:5: note: Revealed type is "Any"
```

The last two lines are both wrong, and neither is reported. With this branch:

```
consumer.py:5: note: Revealed type is "TypedDict(stats_arrays.utils.StatisticsResult, {'mean': float | None, 'mode': float | None, 'median': float | None, 'lower': float | None, 'upper': float | None})"
consumer.py:6: error: Incompatible types in assignment (expression has type "float | None", variable has type "str")  [assignment]
consumer.py:7: error: TypedDict "StatisticsResult" has no key "maen"  [typeddict-item]
```

## What changed

The marker is one empty file plus the packaging entry that puts it in the wheel. The annotations then had to hold up, and `mypy` reported 18 errors on the package.

Most came from `UncertaintyBase.id = None`, which declares the attribute as `None` and so contradicts every distribution that assigns an integer id. `id` and `description` are now declared on the base without a value, since the base is abstract and each distribution sets both.

Two names are exported for downstream code to annotate against. `ParamsArray` was `npt.NDArray[BASE_DTYPE_T]` with a free type variable, meaning "array of anything" wherever it appeared; params arrays are structured arrays, so it is now `npt.NDArray[np.void]`, with the field layout in the docstring because numpy's typing system cannot express it. `StatisticsResult` is a TypedDict for the return value of `statistics()`, with `mean`, `mode`, `median`, `lower` and `upper`, each an optional float.

`one_row_params_array` was typed `Callable -> Callable`, which erased the signature of every method it wraps, so `statistics()` and `pdf()` had no visible types at all. It now carries the wrapped signature through.

That in turn showed two mismatches: `pdf()` is declared to return an array on the base class while every implementation returns an `(xs, ys)` pair, and `BoundedUncertaintyBase.check_bounds_reasonableness()` drops the `threshold` argument its base declares.

## Bugs found on the way

`UncertaintyChoices.add()` rejects distributions without an integer `id`, but the check could never run: the conditions were joined with `and` where `or` was meant, and `hasattr(distribution, "id")` was always true because the base class supplied `id = None`.

The duplicate-id `ValueError` and the already-present warning both formatted values with `{:d}`. The error passed a class object, so building the message raised `TypeError` instead of reporting the duplicate id.

```
>>> "id {:d} in use by {:d}".format(3, NormalUncertainty)
TypeError: unsupported format string passed to type.__format__
```

## Checking

`mypy` runs as a CI job and a pre-commit hook, with `disallow_untyped_defs` and `check_untyped_defs`. The package is clean under both.

Full `--strict` is not usable here: numpy's stubs return `Any` from array operations, which produces 219 findings that say nothing about this code.

`python_version` is unset in the config because current mypy will not target anything below 3.10, and pinning it breaks parsing of numpy's own stubs. The CI job runs 3.12 and the annotations stay 3.9 compatible. SciPy ships no type information and `scipy-stubs` needs 3.11 or newer, so its imports are ignored.

## Notes

`UncertaintyBase.id` and `.description` no longer exist as attributes on the abstract base, where they were `None`. Every concrete distribution sets both, so `NormalUncertainty.id` is unchanged; reading them off `UncertaintyBase` directly now raises `AttributeError`. The changelog records this under breaking changes.

250 tests pass before and after, at every commit on the branch.
